### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 # Alibaba Cloud RDS OpenAPI MCP Server
 MCP server for RDS Services via OPENAPI
 
+<a href="https://glama.ai/mcp/servers/@aliyun/alibabacloud-rds-openapi-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@aliyun/alibabacloud-rds-openapi-mcp-server/badge" alt="Alibaba Cloud RDS OpenAPI Server MCP server" />
+</a>
+
 ## Prerequisites
 1. Install `uv` from [Astral](https://docs.astral.sh/uv/getting-started/installation/) or the [GitHub README](https://github.com/astral-sh/uv#installation)
 2. Install Python using `uv python install 3.12`


### PR DESCRIPTION
This PR adds a badge for the [Alibaba Cloud RDS OpenAPI MCP Server](https://glama.ai/mcp/servers/@aliyun/alibabacloud-rds-openapi-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@aliyun/alibabacloud-rds-openapi-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@aliyun/alibabacloud-rds-openapi-mcp-server/badge" alt="Alibaba Cloud RDS OpenAPI Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.