### PR TITLE
Add 6 new skills and update documentation

### DIFF
--- a/skill/arxiv-watcher/SKILL.md
+++ b/skill/arxiv-watcher/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: arxiv-watcher
+description: Search and summarize papers from ArXiv. Use when the user asks for the latest research, specific topics on ArXiv, or a daily summary of AI papers.
+---
+
+# ArXiv Watcher
+
+This skill interacts with the ArXiv API to find and summarize the latest research papers.
+
+## Capabilities
+
+- **Search**: Find papers by keyword, author, or category.
+- **Summarize**: Fetch the abstract and provide a concise summary.
+- **Save to Memory**: Automatically record summarized papers to `memory/RESEARCH_LOG.md` for long-term tracking.
+- **Deep Dive**: Use `web_fetch` on the PDF link to extract more details if requested.
+
+## Workflow
+
+1. Use `scripts/search_arxiv.sh "<query>"` to get the XML results.
+2. Parse the XML (look for `<entry>`, `<title>`, `<summary>`, and `<link title="pdf">`).
+3. Present the findings to the user.
+4. **MANDATORY**: Append the title, authors, date, and summary of any paper discussed to `memory/RESEARCH_LOG.md`. Use the format:
+   ```markdown
+   ### [YYYY-MM-DD] TITLE_OF_PAPER
+   - **Authors**: Author List
+   - **Link**: ArXiv Link
+   - **Summary**: Brief summary of the paper and its relevance.
+   ```
+
+## Examples
+
+- "Busca los últimos papers sobre LLM reasoning en ArXiv."
+- "Dime de qué trata el paper con ID 2512.08769."
+- "Hazme un resumen de las novedades de hoy en ArXiv sobre agentes."
+
+## Resources
+
+- `scripts/search_arxiv.sh`: Direct API access script.

--- a/skill/arxiv-watcher/_meta.json
+++ b/skill/arxiv-watcher/_meta.json
@@ -1,0 +1,6 @@
+{
+  "ownerId": "kn7c8ew58zsqxsn7a50925ypk97zzatv",
+  "slug": "arxiv-watcher",
+  "version": "1.0.0",
+  "publishedAt": 1769434876997
+}

--- a/skill/arxiv-watcher/scripts/search_arxiv.sh
+++ b/skill/arxiv-watcher/scripts/search_arxiv.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# scripts/search_arxiv.sh
+QUERY=$1
+COUNT=${2:-5}
+# Use curl to query ArXiv API
+curl -sL "https://export.arxiv.org/api/query?search_query=all:$QUERY&start=0&max_results=$COUNT&sortBy=submittedDate&sortOrder=descending"

--- a/skill/cli-anything/SKILL.md
+++ b/skill/cli-anything/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: cli-anything
+description: Generate or refine agent-usable CLIs for existing software/codebases using the CLI-Anything methodology. Use when the user wants to turn a GUI app, desktop tool, repository, SDK, or web/API surface into a structured CLI for agents; when adapting CLI-Anything into OpenClaw workflows; or when packaging a generated harness as an OpenClaw-compatible skill.
+---
+
+# CLI-Anything
+
+Use this skill to work with the local `CLI-Anything/` repository in the workspace and turn its methodology into something usable from OpenClaw.
+
+## What this skill is for
+
+Use it for three common cases:
+
+1. **Assess feasibility** — inspect a target app/repo and decide whether CLI-Anything is a good fit.
+2. **Use an existing harness** — work with one of the repo's prebuilt `agent-harness` examples.
+3. **Wrap for OpenClaw** — turn CLI-Anything guidance or an existing harness into an OpenClaw skill/workflow.
+
+## Local source of truth
+
+The repository is expected at:
+
+- `/root/.openclaw/workspace/CLI-Anything`
+
+Read these first when needed:
+
+- `CLI-Anything/README.md` — overall platform and examples
+- `CLI-Anything/cli-anything-plugin/HARNESS.md` — generation methodology and quality bar
+- `CLI-Anything/cli-anything-plugin/README.md` — plugin behavior and expected output layout
+
+For a fast survey of bundled examples, read `references/bundled-harnesses.md`.
+
+## Core workflow
+
+### 1) Classify the user's request
+
+Decide which path applies:
+
+- **Methodology request**: user wants to understand or apply CLI-Anything generally
+- **Existing harness request**: user wants to use/demo one of the included examples like GIMP or LibreOffice
+- **Packaging request**: user wants an OpenClaw skill or ClawHub package derived from CLI-Anything
+
+### 2) Inspect prerequisites
+
+Before promising execution, check:
+
+- Python 3.10+
+- target software presence if using a real harness backend
+- whether the request is about:
+  - building a harness
+  - running a generated CLI
+  - packaging/publishing
+
+### 3) Prefer existing harnesses before generation
+
+If the repo already includes a matching harness under `<software>/agent-harness/`, use that as the baseline instead of pretending generation has to happen from scratch.
+
+### 4) For OpenClaw packaging, separate method from implementation
+
+CLI-Anything itself is not a native OpenClaw skill package. When adapting it:
+
+- keep the OpenClaw `SKILL.md` focused on **when to use** and **how to navigate the local repo**
+- move large methodology text into references
+- do not claim that `/plugin` or `/cli-anything` slash commands are directly available inside OpenClaw unless you have actually wired them up
+
+## Practical guidance
+
+### When the user wants to use an existing bundled harness
+
+1. Locate `<software>/agent-harness/`
+2. Read its `setup.py`, package layout, and local README/SOP file
+3. Identify hard dependencies on the real software backend
+4. Install or verify Python requirements only as needed
+5. Validate the CLI entry point and a minimal command
+
+### When the user wants to make a new app agent-native
+
+Use CLI-Anything as methodology, not magic:
+
+1. Analyze backend engine, data model, existing CLI/API hooks
+2. Define command groups and state model
+3. Create or refine `agent-harness/`
+4. Add tests and a `TEST.md`
+5. Install the resulting package to PATH
+6. Verify real backend execution, not mock-only behavior
+
+### When the user wants an OpenClaw skill
+
+There are two good outputs:
+
+- **Method skill**: teaches OpenClaw how to use CLI-Anything on local repos
+- **Harness skill**: wraps one generated CLI or one concrete software target
+
+Default to a **method skill** unless the user clearly wants a single app workflow.
+
+## Rules
+
+- Do not say CLI-Anything is already a native OpenClaw skill unless you created that wrapper.
+- Do not promise a generated CLI works until you verify its entry point and real backend dependencies.
+- Treat third-party generated code as reviewable output, not automatically trusted output.
+- For publishing, require explicit user intent before pushing anything external.
+- If packaging for ClawHub, keep the skill lean and point to local references instead of pasting huge docs into `SKILL.md`.
+
+## Useful script
+
+Use `scripts/inspect_cli_anything.py` to quickly inspect the local repo and enumerate bundled harnesses. It prints JSON with:
+
+- whether the repo exists
+- discovered harnesses
+- whether each harness has `setup.py`, package directory, README, and E2E tests
+
+Run:
+
+```bash
+python3 /root/.openclaw/workspace/skills/cli-anything/scripts/inspect_cli_anything.py
+```
+
+Use `scripts/recommend_harness.py` to rank the bundled harnesses and suggest good first validation targets.
+
+Run:
+
+```bash
+python3 /root/.openclaw/workspace/skills/cli-anything/scripts/recommend_harness.py
+```
+
+## Helpful local paths
+
+- Repo root: `/root/.openclaw/workspace/CLI-Anything`
+- Plugin docs: `/root/.openclaw/workspace/CLI-Anything/cli-anything-plugin`
+- Example harnesses: `/root/.openclaw/workspace/CLI-Anything/*/agent-harness`
+
+## Reference files
+
+- `references/bundled-harnesses.md` — quick map of included examples
+- `references/openclaw-adaptation-notes.md` — how to package CLI-Anything ideas into OpenClaw skills
+- `references/validated-example-gimp.md` — first locally verified runnable example

--- a/skill/cli-anything/_meta.json
+++ b/skill/cli-anything/_meta.json
@@ -1,0 +1,6 @@
+{
+  "ownerId": "kn7brxcy9kprdrmg4h3zyz256982sh02",
+  "slug": "cli-anything",
+  "version": "0.1.0",
+  "publishedAt": 1773306179586
+}

--- a/skill/cli-anything/references/bundled-harnesses.md
+++ b/skill/cli-anything/references/bundled-harnesses.md
@@ -1,0 +1,46 @@
+# Bundled harnesses in CLI-Anything
+
+Use this as a quick map before reading a specific harness deeply.
+
+## Included examples observed in the local repo
+
+- `gimp/agent-harness`
+- `blender/agent-harness`
+- `inkscape/agent-harness`
+- `audacity/agent-harness`
+- `libreoffice/agent-harness`
+- `obs-studio/agent-harness`
+- `kdenlive/agent-harness`
+- `shotcut/agent-harness`
+- `zoom/agent-harness`
+- `drawio/agent-harness`
+- `anygen/agent-harness`
+
+## Common structure to expect
+
+Most examples contain:
+
+- `setup.py`
+- a PEP 420 namespace package under `cli_anything/<software>/`
+- a software-specific SOP like `GIMP.md` or `LIBREOFFICE.md`
+- `tests/test_core.py`
+- `tests/test_full_e2e.py`
+- `tests/TEST.md`
+
+## What to verify before claiming one is usable
+
+1. The target software/backend is installed
+2. The Python package can be installed or imported
+3. The console entry point resolves
+4. A minimal command works
+5. Any E2E claim uses the real software backend, not only synthetic tests
+
+## Recommended first targets
+
+If you need a smaller proof-of-concept, start with examples that look structurally complete and have straightforward file-based workflows, such as:
+
+- `gimp`
+- `inkscape`
+- `libreoffice`
+
+More environment-sensitive examples may need extra services, APIs, or media tools.

--- a/skill/cli-anything/references/openclaw-adaptation-notes.md
+++ b/skill/cli-anything/references/openclaw-adaptation-notes.md
@@ -1,0 +1,51 @@
+# Adapting CLI-Anything into OpenClaw
+
+CLI-Anything is a methodology repo plus plugin/command assets, not a native OpenClaw skill package.
+
+## Safe adaptation pattern
+
+1. Keep OpenClaw `SKILL.md` short and procedural
+2. Store heavier methodology in references
+3. Point to the local `CLI-Anything/` checkout as the implementation source
+4. Distinguish clearly between:
+   - plugin commands for Claude Code / OpenCode
+   - local Python harnesses
+   - OpenClaw skill wrappers
+
+## Good packaging targets
+
+### Option A — method skill
+
+Create an OpenClaw skill that teaches the agent how to:
+
+- inspect the local CLI-Anything repo
+- choose a harness or target app
+- verify dependencies
+- adapt generated outputs into OpenClaw-friendly workflows
+
+### Option B — concrete harness skill
+
+Wrap one concrete generated CLI, for example a `cli-anything-libreoffice` workflow.
+This is often easier to test than packaging the whole methodology.
+
+## Publishing cautions
+
+Before publishing to ClawHub:
+
+- verify there is real implementation value beyond copied docs
+- avoid bundling unnecessary large third-party source trees in the skill unless intentionally distributing them
+- make sure the description says whether the skill is:
+  - methodology only
+  - a wrapper around a local repo
+  - a distributable harness with runnable scripts
+
+## Recommended wording
+
+Prefer wording like:
+
+- "Uses a local checkout of CLI-Anything to guide harness generation"
+- "Wraps existing CLI-Anything harnesses for OpenClaw workflows"
+
+Avoid wording like:
+
+- "Provides full CLI-Anything functionality" unless you actually wired all of it up

--- a/skill/cli-anything/references/validated-example-gimp.md
+++ b/skill/cli-anything/references/validated-example-gimp.md
@@ -1,0 +1,87 @@
+# Validated example: gimp harness
+
+This is the first locally validated example for the OpenClaw `cli-anything` skill.
+
+## What was verified
+
+### Environment
+
+- Python present: `Python 3.12.3`
+- Local repo present: `/root/.openclaw/workspace/CLI-Anything`
+
+### Python dependencies installed for the harness
+
+Installed into the current machine Python environment:
+
+- `Pillow`
+- `numpy`
+- `prompt_toolkit`
+
+### Harness installation
+
+Installed from:
+
+- `/root/.openclaw/workspace/CLI-Anything/gimp/agent-harness`
+
+Command used conceptually:
+
+```bash
+python3 -m pip install --break-system-packages -e /root/.openclaw/workspace/CLI-Anything/gimp/agent-harness
+```
+
+### Entry point verification
+
+Verified command:
+
+```bash
+cli-anything-gimp --help
+```
+
+The CLI loaded successfully and exposed command groups including:
+
+- `canvas`
+- `draw`
+- `export`
+- `filter`
+- `layer`
+- `media`
+- `project`
+- `repl`
+- `session`
+
+### Minimal functional verification
+
+Verified JSON project creation:
+
+```bash
+cli-anything-gimp --json project new --width 320 --height 240 -o /root/.openclaw/workspace/tmp-gimp-project.json
+```
+
+Observed result:
+
+- JSON printed to stdout
+- project file created successfully
+- output file path:
+  - `/root/.openclaw/workspace/tmp-gimp-project.json`
+
+## Important note
+
+The `gimp` harness is a good first demonstration target because it is runnable in the current environment after Python dependency installation.
+
+However, its packaging/docs are not perfectly aligned:
+
+- `setup.py` describes it as a GIMP batch-mode harness
+- the README describes a Pillow-based image editing CLI
+
+Treat this harness as:
+
+- **validated enough for local demonstration**
+- **not yet proof that every CLI-Anything harness exactly matches its stated backend model**
+
+## Recommended use in the skill
+
+When using the `cli-anything` method skill:
+
+1. Prefer `gimp` as the first runnable example
+2. Use it to demonstrate harness inspection, installation, and entry-point checks
+3. Avoid over-claiming that all bundled harnesses are equally verified until they are tested one by one

--- a/skill/cli-anything/scripts/inspect_cli_anything.py
+++ b/skill/cli-anything/scripts/inspect_cli_anything.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+import json
+from pathlib import Path
+
+ROOT = Path('/root/.openclaw/workspace/CLI-Anything')
+
+
+def detect_harnesses(root: Path):
+    items = []
+    if not root.exists():
+        return items
+    for setup_py in sorted(root.glob('*/agent-harness/setup.py')):
+        harness_dir = setup_py.parent
+        software_dir = harness_dir.parent
+        name = software_dir.name
+        pkg_root = harness_dir / 'cli_anything'
+        readmes = list(harness_dir.glob('*.md')) + list((pkg_root / name).glob('README.md')) if (pkg_root / name).exists() else list(harness_dir.glob('*.md'))
+        tests = list(harness_dir.glob('cli_anything/**/tests/test_full_e2e.py'))
+        items.append({
+            'name': name,
+            'path': str(harness_dir),
+            'has_setup_py': setup_py.exists(),
+            'has_pkg_dir': (pkg_root / name).exists(),
+            'has_readme': any(p.name.lower() == 'readme.md' for p in readmes),
+            'has_e2e_tests': bool(tests),
+        })
+    return items
+
+
+def main():
+    data = {
+        'repo_exists': ROOT.exists(),
+        'repo_path': str(ROOT),
+        'harnesses': detect_harnesses(ROOT),
+    }
+    data['harness_count'] = len(data['harnesses'])
+    print(json.dumps(data, ensure_ascii=False, indent=2))
+
+
+if __name__ == '__main__':
+    main()

--- a/skill/cli-anything/scripts/recommend_harness.py
+++ b/skill/cli-anything/scripts/recommend_harness.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+import json
+import subprocess
+from pathlib import Path
+
+INSPECT = Path('/root/.openclaw/workspace/skills/cli-anything/scripts/inspect_cli_anything.py')
+
+
+def score(item):
+    s = 0
+    if item.get('has_setup_py'):
+        s += 3
+    if item.get('has_pkg_dir'):
+        s += 3
+    if item.get('has_readme'):
+        s += 2
+    if item.get('has_e2e_tests'):
+        s += 2
+    name = item.get('name', '')
+    if name in {'gimp', 'inkscape', 'libreoffice'}:
+        s += 2
+    if name in {'zoom', 'obs-studio', 'anygen'}:
+        s -= 1
+    return s
+
+
+def main():
+    raw = subprocess.check_output(['python3', str(INSPECT)], text=True)
+    data = json.loads(raw)
+    harnesses = data.get('harnesses', [])
+    ranked = []
+    for item in harnesses:
+        item = dict(item)
+        item['score'] = score(item)
+        ranked.append(item)
+    ranked.sort(key=lambda x: (-x['score'], x['name']))
+    out = {
+        'repo_exists': data.get('repo_exists', False),
+        'recommended': ranked[:5],
+        'best': ranked[0] if ranked else None,
+    }
+    print(json.dumps(out, ensure_ascii=False, indent=2))
+
+
+if __name__ == '__main__':
+    main()

--- a/skill/data-analyst/SKILL.md
+++ b/skill/data-analyst/SKILL.md
@@ -1,0 +1,572 @@
+---
+name: data-analyst
+version: 1.0.0
+description: "Data visualization, report generation, SQL queries, and spreadsheet automation. Transform your AI agent into a data-savvy analyst that turns raw data into actionable insights."
+author: openclaw
+---
+
+# Data Analyst Skill 📊
+
+**Turn your AI agent into a data analysis powerhouse.**
+
+Query databases, analyze spreadsheets, create visualizations, and generate insights that drive decisions.
+
+---
+
+## What This Skill Does
+
+✅ **SQL Queries** — Write and execute queries against databases
+✅ **Spreadsheet Analysis** — Process CSV, Excel, Google Sheets data
+✅ **Data Visualization** — Create charts, graphs, and dashboards
+✅ **Report Generation** — Automated reports with insights
+✅ **Data Cleaning** — Handle missing data, outliers, formatting
+✅ **Statistical Analysis** — Descriptive stats, trends, correlations
+
+---
+
+## Quick Start
+
+1. Configure your data sources in `TOOLS.md`:
+```markdown
+### Data Sources
+- Primary DB: [Connection string or description]
+- Spreadsheets: [Google Sheets URL / local path]
+- Data warehouse: [BigQuery/Snowflake/etc.]
+```
+
+2. Set up your workspace:
+```bash
+./scripts/data-init.sh
+```
+
+3. Start analyzing!
+
+---
+
+## SQL Query Patterns
+
+### Common Query Templates
+
+**Basic Data Exploration**
+```sql
+-- Row count
+SELECT COUNT(*) FROM table_name;
+
+-- Sample data
+SELECT * FROM table_name LIMIT 10;
+
+-- Column statistics
+SELECT 
+    column_name,
+    COUNT(*) as count,
+    COUNT(DISTINCT column_name) as unique_values,
+    MIN(column_name) as min_val,
+    MAX(column_name) as max_val
+FROM table_name
+GROUP BY column_name;
+```
+
+**Time-Based Analysis**
+```sql
+-- Daily aggregation
+SELECT 
+    DATE(created_at) as date,
+    COUNT(*) as daily_count,
+    SUM(amount) as daily_total
+FROM transactions
+GROUP BY DATE(created_at)
+ORDER BY date DESC;
+
+-- Month-over-month comparison
+SELECT 
+    DATE_TRUNC('month', created_at) as month,
+    COUNT(*) as count,
+    LAG(COUNT(*)) OVER (ORDER BY DATE_TRUNC('month', created_at)) as prev_month,
+    (COUNT(*) - LAG(COUNT(*)) OVER (ORDER BY DATE_TRUNC('month', created_at))) / 
+        NULLIF(LAG(COUNT(*)) OVER (ORDER BY DATE_TRUNC('month', created_at)), 0) * 100 as growth_pct
+FROM transactions
+GROUP BY DATE_TRUNC('month', created_at)
+ORDER BY month;
+```
+
+**Cohort Analysis**
+```sql
+-- User cohort by signup month
+SELECT 
+    DATE_TRUNC('month', u.created_at) as cohort_month,
+    DATE_TRUNC('month', o.created_at) as activity_month,
+    COUNT(DISTINCT u.id) as users
+FROM users u
+LEFT JOIN orders o ON u.id = o.user_id
+GROUP BY cohort_month, activity_month
+ORDER BY cohort_month, activity_month;
+```
+
+**Funnel Analysis**
+```sql
+-- Conversion funnel
+WITH funnel AS (
+    SELECT
+        COUNT(DISTINCT CASE WHEN event = 'page_view' THEN user_id END) as views,
+        COUNT(DISTINCT CASE WHEN event = 'signup' THEN user_id END) as signups,
+        COUNT(DISTINCT CASE WHEN event = 'purchase' THEN user_id END) as purchases
+    FROM events
+    WHERE date >= CURRENT_DATE - INTERVAL '30 days'
+)
+SELECT 
+    views,
+    signups,
+    ROUND(signups * 100.0 / NULLIF(views, 0), 2) as signup_rate,
+    purchases,
+    ROUND(purchases * 100.0 / NULLIF(signups, 0), 2) as purchase_rate
+FROM funnel;
+```
+
+---
+
+## Data Cleaning
+
+### Common Data Quality Issues
+
+| Issue | Detection | Solution |
+|-------|-----------|----------|
+| **Missing values** | `IS NULL` or empty string | Impute, drop, or flag |
+| **Duplicates** | `GROUP BY` with `HAVING COUNT(*) > 1` | Deduplicate with rules |
+| **Outliers** | Z-score > 3 or IQR method | Investigate, cap, or exclude |
+| **Inconsistent formats** | Sample and pattern match | Standardize with transforms |
+| **Invalid values** | Range checks, referential integrity | Validate and correct |
+
+### Data Cleaning SQL Patterns
+
+```sql
+-- Find duplicates
+SELECT email, COUNT(*)
+FROM users
+GROUP BY email
+HAVING COUNT(*) > 1;
+
+-- Find nulls
+SELECT 
+    COUNT(*) as total,
+    SUM(CASE WHEN email IS NULL THEN 1 ELSE 0 END) as null_emails,
+    SUM(CASE WHEN name IS NULL THEN 1 ELSE 0 END) as null_names
+FROM users;
+
+-- Standardize text
+UPDATE products
+SET category = LOWER(TRIM(category));
+
+-- Remove outliers (IQR method)
+WITH stats AS (
+    SELECT 
+        PERCENTILE_CONT(0.25) WITHIN GROUP (ORDER BY value) as q1,
+        PERCENTILE_CONT(0.75) WITHIN GROUP (ORDER BY value) as q3
+    FROM data
+)
+SELECT * FROM data, stats
+WHERE value BETWEEN q1 - 1.5*(q3-q1) AND q3 + 1.5*(q3-q1);
+```
+
+### Data Cleaning Checklist
+
+```markdown
+# Data Quality Audit: [Dataset]
+
+## Row-Level Checks
+- [ ] Total row count: [X]
+- [ ] Duplicate rows: [X]
+- [ ] Rows with any null: [X]
+
+## Column-Level Checks
+| Column | Type | Nulls | Unique | Min | Max | Issues |
+|--------|------|-------|--------|-----|-----|--------|
+| [col] | [type] | [n] | [n] | [v] | [v] | [notes] |
+
+## Data Lineage
+- Source: [Where data came from]
+- Last updated: [Date]
+- Known issues: [List]
+
+## Cleaning Actions Taken
+1. [Action and reason]
+2. [Action and reason]
+```
+
+---
+
+## Spreadsheet Analysis
+
+### CSV/Excel Processing with Python
+
+```python
+import pandas as pd
+
+# Load data
+df = pd.read_csv('data.csv')  # or pd.read_excel('data.xlsx')
+
+# Basic exploration
+print(df.shape)  # (rows, columns)
+print(df.info())  # Column types and nulls
+print(df.describe())  # Numeric statistics
+
+# Data cleaning
+df = df.drop_duplicates()
+df['date'] = pd.to_datetime(df['date'])
+df['amount'] = df['amount'].fillna(0)
+
+# Analysis
+summary = df.groupby('category').agg({
+    'amount': ['sum', 'mean', 'count'],
+    'quantity': 'sum'
+}).round(2)
+
+# Export
+summary.to_csv('analysis_output.csv')
+```
+
+### Common Pandas Operations
+
+```python
+# Filtering
+filtered = df[df['status'] == 'active']
+filtered = df[df['amount'] > 1000]
+filtered = df[df['date'].between('2024-01-01', '2024-12-31')]
+
+# Aggregation
+by_category = df.groupby('category')['amount'].sum()
+pivot = df.pivot_table(values='amount', index='month', columns='category', aggfunc='sum')
+
+# Window functions
+df['running_total'] = df['amount'].cumsum()
+df['pct_change'] = df['amount'].pct_change()
+df['rolling_avg'] = df['amount'].rolling(window=7).mean()
+
+# Merging
+merged = pd.merge(df1, df2, on='id', how='left')
+```
+
+---
+
+## Data Visualization
+
+### Chart Selection Guide
+
+| Data Type | Best Chart | Use When |
+|-----------|------------|----------|
+| Trend over time | Line chart | Showing patterns/changes over time |
+| Category comparison | Bar chart | Comparing discrete categories |
+| Part of whole | Pie/Donut | Showing proportions (≤5 categories) |
+| Distribution | Histogram | Understanding data spread |
+| Correlation | Scatter plot | Relationship between two variables |
+| Many categories | Horizontal bar | Ranking or comparing many items |
+| Geographic | Map | Location-based data |
+
+### Python Visualization with Matplotlib/Seaborn
+
+```python
+import matplotlib.pyplot as plt
+import seaborn as sns
+
+# Set style
+plt.style.use('seaborn-v0_8-whitegrid')
+sns.set_palette("husl")
+
+# Line chart (trends)
+plt.figure(figsize=(10, 6))
+plt.plot(df['date'], df['value'], marker='o')
+plt.title('Trend Over Time')
+plt.xlabel('Date')
+plt.ylabel('Value')
+plt.xticks(rotation=45)
+plt.tight_layout()
+plt.savefig('trend.png', dpi=150)
+
+# Bar chart (comparisons)
+plt.figure(figsize=(10, 6))
+sns.barplot(data=df, x='category', y='amount')
+plt.title('Amount by Category')
+plt.xticks(rotation=45)
+plt.tight_layout()
+plt.savefig('comparison.png', dpi=150)
+
+# Heatmap (correlations)
+plt.figure(figsize=(10, 8))
+sns.heatmap(df.corr(), annot=True, cmap='coolwarm', center=0)
+plt.title('Correlation Matrix')
+plt.tight_layout()
+plt.savefig('correlation.png', dpi=150)
+```
+
+### ASCII Charts (Quick Terminal Visualization)
+
+When you can't generate images, use ASCII:
+
+```
+Revenue by Month (in $K)
+========================
+Jan: ████████████████ 160
+Feb: ██████████████████ 180
+Mar: ████████████████████████ 240
+Apr: ██████████████████████ 220
+May: ██████████████████████████ 260
+Jun: ████████████████████████████ 280
+```
+
+---
+
+## Report Generation
+
+### Standard Report Template
+
+```markdown
+# [Report Name]
+**Period:** [Date range]
+**Generated:** [Date]
+**Author:** [Agent/Human]
+
+## Executive Summary
+[2-3 sentences with key findings]
+
+## Key Metrics
+
+| Metric | Current | Previous | Change |
+|--------|---------|----------|--------|
+| [Metric] | [Value] | [Value] | [+/-X%] |
+
+## Detailed Analysis
+
+### [Section 1]
+[Analysis with supporting data]
+
+### [Section 2]
+[Analysis with supporting data]
+
+## Visualizations
+[Insert charts]
+
+## Insights
+1. **[Insight]**: [Supporting evidence]
+2. **[Insight]**: [Supporting evidence]
+
+## Recommendations
+1. [Actionable recommendation]
+2. [Actionable recommendation]
+
+## Methodology
+- Data source: [Source]
+- Date range: [Range]
+- Filters applied: [Filters]
+- Known limitations: [Limitations]
+
+## Appendix
+[Supporting data tables]
+```
+
+### Automated Report Script
+
+```bash
+#!/bin/bash
+# generate-report.sh
+
+# Pull latest data
+python scripts/extract_data.py --output data/latest.csv
+
+# Run analysis
+python scripts/analyze.py --input data/latest.csv --output reports/
+
+# Generate report
+python scripts/format_report.py --template weekly --output reports/weekly-$(date +%Y-%m-%d).md
+
+echo "Report generated: reports/weekly-$(date +%Y-%m-%d).md"
+```
+
+---
+
+## Statistical Analysis
+
+### Descriptive Statistics
+
+| Statistic | What It Tells You | Use Case |
+|-----------|-------------------|----------|
+| **Mean** | Average value | Central tendency |
+| **Median** | Middle value | Robust to outliers |
+| **Mode** | Most common | Categorical data |
+| **Std Dev** | Spread around mean | Variability |
+| **Min/Max** | Range | Data boundaries |
+| **Percentiles** | Distribution shape | Benchmarking |
+
+### Quick Stats with Python
+
+```python
+# Full descriptive statistics
+stats = df['amount'].describe()
+print(stats)
+
+# Additional stats
+print(f"Median: {df['amount'].median()}")
+print(f"Mode: {df['amount'].mode()[0]}")
+print(f"Skewness: {df['amount'].skew()}")
+print(f"Kurtosis: {df['amount'].kurtosis()}")
+
+# Correlation
+correlation = df['sales'].corr(df['marketing_spend'])
+print(f"Correlation: {correlation:.3f}")
+```
+
+### Statistical Tests Quick Reference
+
+| Test | Use Case | Python |
+|------|----------|--------|
+| T-test | Compare two means | `scipy.stats.ttest_ind(a, b)` |
+| Chi-square | Categorical independence | `scipy.stats.chi2_contingency(table)` |
+| ANOVA | Compare 3+ means | `scipy.stats.f_oneway(a, b, c)` |
+| Pearson | Linear correlation | `scipy.stats.pearsonr(x, y)` |
+
+---
+
+## Analysis Workflow
+
+### Standard Analysis Process
+
+1. **Define the Question**
+   - What are we trying to answer?
+   - What decisions will this inform?
+
+2. **Understand the Data**
+   - What data is available?
+   - What's the structure and quality?
+
+3. **Clean and Prepare**
+   - Handle missing values
+   - Fix data types
+   - Remove duplicates
+
+4. **Explore**
+   - Descriptive statistics
+   - Initial visualizations
+   - Identify patterns
+
+5. **Analyze**
+   - Deep dive into findings
+   - Statistical tests if needed
+   - Validate hypotheses
+
+6. **Communicate**
+   - Clear visualizations
+   - Actionable insights
+   - Recommendations
+
+### Analysis Request Template
+
+```markdown
+# Analysis Request
+
+## Question
+[What are we trying to answer?]
+
+## Context
+[Why does this matter? What decision will it inform?]
+
+## Data Available
+- [Dataset 1]: [Description]
+- [Dataset 2]: [Description]
+
+## Expected Output
+- [Deliverable 1]
+- [Deliverable 2]
+
+## Timeline
+[When is this needed?]
+
+## Notes
+[Any constraints or considerations]
+```
+
+---
+
+## Scripts
+
+### data-init.sh
+Initialize your data analysis workspace.
+
+### query.sh
+Quick SQL query execution.
+
+```bash
+# Run query from file
+./scripts/query.sh --file queries/daily-report.sql
+
+# Run inline query
+./scripts/query.sh "SELECT COUNT(*) FROM users"
+
+# Save output to file
+./scripts/query.sh --file queries/export.sql --output data/export.csv
+```
+
+### analyze.py
+Python analysis toolkit.
+
+```bash
+# Basic analysis
+python scripts/analyze.py --input data/sales.csv
+
+# With specific analysis type
+python scripts/analyze.py --input data/sales.csv --type cohort
+
+# Generate report
+python scripts/analyze.py --input data/sales.csv --report weekly
+```
+
+---
+
+## Integration Tips
+
+### With Other Skills
+
+| Skill | Integration |
+|-------|-------------|
+| **Marketing** | Analyze campaign performance, content metrics |
+| **Sales** | Pipeline analytics, conversion analysis |
+| **Business Dev** | Market research data, competitor analysis |
+
+### Common Data Sources
+
+- **Databases:** PostgreSQL, MySQL, SQLite
+- **Warehouses:** BigQuery, Snowflake, Redshift
+- **Spreadsheets:** Google Sheets, Excel, CSV
+- **APIs:** REST endpoints, GraphQL
+- **Files:** JSON, Parquet, XML
+
+---
+
+## Best Practices
+
+1. **Start with the question** — Know what you're trying to answer
+2. **Validate your data** — Garbage in = garbage out
+3. **Document everything** — Queries, assumptions, decisions
+4. **Visualize appropriately** — Right chart for right data
+5. **Show your work** — Methodology matters
+6. **Lead with insights** — Not just data dumps
+7. **Make it actionable** — "So what?" → "Now what?"
+8. **Version your queries** — Track changes over time
+
+---
+
+## Common Mistakes
+
+❌ **Confirmation bias** — Looking for data to support a conclusion
+❌ **Correlation ≠ causation** — Be careful with claims
+❌ **Cherry-picking** — Using only favorable data
+❌ **Ignoring outliers** — Investigate before removing
+❌ **Over-complicating** — Simple analysis often wins
+❌ **No context** — Numbers without comparison are meaningless
+
+---
+
+## License
+
+**License:** MIT — use freely, modify, distribute.
+
+---
+
+*"The goal is to turn data into information, and information into insight." — Carly Fiorina*

--- a/skill/data-analyst/_meta.json
+++ b/skill/data-analyst/_meta.json
@@ -1,0 +1,6 @@
+{
+  "ownerId": "kn7cpmgq5bpf1mp69bpd7n9as180nssd",
+  "slug": "data-analyst",
+  "version": "1.0.0",
+  "publishedAt": 1770410537278
+}

--- a/skill/data-analyst/scripts/data-init.sh
+++ b/skill/data-analyst/scripts/data-init.sh
@@ -1,0 +1,235 @@
+#!/bin/bash
+# data-init.sh - Initialize data analysis workspace
+# Usage: ./data-init.sh
+
+DATA_DIR="${HOME}/.openclaw/workspace/data-analysis"
+
+echo "🚀 Initializing Data Analysis Workspace"
+echo "======================================="
+
+# Create directory structure
+mkdir -p "$DATA_DIR"/{data,queries,reports,notebooks,scripts}
+
+# Create queries directory with common patterns
+cat > "$DATA_DIR/queries/README.md" << 'EOF'
+# SQL Queries
+
+Store reusable SQL queries here.
+
+## Naming Convention
+- `daily-<name>.sql` - Daily reports
+- `weekly-<name>.sql` - Weekly reports
+- `adhoc-<name>.sql` - One-off queries
+- `template-<name>.sql` - Reusable templates
+EOF
+
+cat > "$DATA_DIR/queries/template-exploration.sql" << 'EOF'
+-- Data Exploration Template
+-- Replace TABLE_NAME with your table
+
+-- Row count
+SELECT COUNT(*) as total_rows FROM TABLE_NAME;
+
+-- Sample data
+SELECT * FROM TABLE_NAME LIMIT 10;
+
+-- Column overview (PostgreSQL)
+-- SELECT column_name, data_type, is_nullable 
+-- FROM information_schema.columns 
+-- WHERE table_name = 'TABLE_NAME';
+
+-- Null analysis
+-- SELECT 
+--     COUNT(*) as total,
+--     SUM(CASE WHEN column_name IS NULL THEN 1 ELSE 0 END) as nulls,
+--     ROUND(SUM(CASE WHEN column_name IS NULL THEN 1 ELSE 0 END) * 100.0 / COUNT(*), 2) as null_pct
+-- FROM TABLE_NAME;
+EOF
+
+# Create report templates
+cat > "$DATA_DIR/reports/README.md" << 'EOF'
+# Reports Directory
+
+Generated reports go here.
+
+## Report Types
+- `weekly-YYYY-MM-DD.md` - Weekly analytics
+- `monthly-YYYY-MM.md` - Monthly summaries
+- `adhoc-<name>.md` - One-off analyses
+EOF
+
+cat > "$DATA_DIR/reports/template-analysis.md" << 'EOF'
+# Analysis Report: [Title]
+
+**Date:** [Date]
+**Author:** [Name]
+**Status:** Draft
+
+## Executive Summary
+[2-3 sentences with key findings]
+
+## Question
+[What are we trying to answer?]
+
+## Data Sources
+- [Source 1]: [Description]
+- [Source 2]: [Description]
+
+## Methodology
+[How we approached the analysis]
+
+## Findings
+
+### Key Metrics
+| Metric | Value | Change | Notes |
+|--------|-------|--------|-------|
+| | | | |
+
+### Insights
+1. **[Insight]**: [Supporting evidence]
+2. **[Insight]**: [Supporting evidence]
+
+## Visualizations
+[Insert charts/graphs]
+
+## Recommendations
+1. [Action to take]
+2. [Action to take]
+
+## Appendix
+[Supporting data tables, SQL queries used]
+EOF
+
+# Create Python analysis template
+cat > "$DATA_DIR/scripts/analyze_template.py" << 'EOF'
+#!/usr/bin/env python3
+"""
+Data Analysis Template
+Usage: python analyze_template.py --input <file.csv>
+"""
+
+import pandas as pd
+import argparse
+from datetime import datetime
+
+def load_data(filepath):
+    """Load data from CSV or Excel."""
+    if filepath.endswith('.csv'):
+        return pd.read_csv(filepath)
+    elif filepath.endswith(('.xlsx', '.xls')):
+        return pd.read_excel(filepath)
+    else:
+        raise ValueError(f"Unsupported file type: {filepath}")
+
+def explore_data(df):
+    """Basic data exploration."""
+    print("\n=== DATA OVERVIEW ===")
+    print(f"Shape: {df.shape[0]} rows, {df.shape[1]} columns")
+    print(f"\nColumn Types:\n{df.dtypes}")
+    print(f"\nMissing Values:\n{df.isnull().sum()}")
+    print(f"\nBasic Statistics:\n{df.describe()}")
+    return df
+
+def clean_data(df):
+    """Basic data cleaning."""
+    # Remove duplicates
+    initial_rows = len(df)
+    df = df.drop_duplicates()
+    print(f"Removed {initial_rows - len(df)} duplicate rows")
+    
+    # Report on nulls
+    null_cols = df.columns[df.isnull().any()].tolist()
+    if null_cols:
+        print(f"Columns with nulls: {null_cols}")
+    
+    return df
+
+def analyze(df):
+    """Main analysis logic - customize this."""
+    print("\n=== ANALYSIS ===")
+    # Add your analysis here
+    # Example:
+    # - Aggregations
+    # - Groupby operations
+    # - Statistical tests
+    return df
+
+def main():
+    parser = argparse.ArgumentParser(description='Data Analysis Script')
+    parser.add_argument('--input', '-i', required=True, help='Input file path')
+    parser.add_argument('--output', '-o', help='Output file path')
+    args = parser.parse_args()
+    
+    print(f"Loading data from: {args.input}")
+    df = load_data(args.input)
+    
+    df = explore_data(df)
+    df = clean_data(df)
+    df = analyze(df)
+    
+    if args.output:
+        df.to_csv(args.output, index=False)
+        print(f"\nResults saved to: {args.output}")
+    
+    print("\n✅ Analysis complete!")
+
+if __name__ == '__main__':
+    main()
+EOF
+chmod +x "$DATA_DIR/scripts/analyze_template.py"
+
+# Create data quality checklist
+cat > "$DATA_DIR/data-quality-checklist.md" << 'EOF'
+# Data Quality Checklist
+
+Use this for every new dataset.
+
+## Dataset: [Name]
+**Source:** [Where it came from]
+**Date:** [When received/pulled]
+**Rows:** [Count]
+**Columns:** [Count]
+
+## Completeness
+- [ ] Row count matches expected
+- [ ] No unexpected nulls
+- [ ] All required columns present
+
+## Accuracy
+- [ ] Values in expected ranges
+- [ ] Dates are valid
+- [ ] IDs/keys are valid
+
+## Consistency
+- [ ] No duplicate primary keys
+- [ ] Consistent formatting (dates, text case)
+- [ ] Referential integrity (foreign keys valid)
+
+## Timeliness
+- [ ] Data is current enough for analysis
+- [ ] Timestamp columns are recent
+
+## Issues Found
+| Issue | Severity | Resolution |
+|-------|----------|------------|
+| | | |
+
+## Cleaning Actions Taken
+1. 
+2. 
+3. 
+EOF
+
+echo "✅ Created: $DATA_DIR/data/"
+echo "✅ Created: $DATA_DIR/queries/"
+echo "✅ Created: $DATA_DIR/reports/"
+echo "✅ Created: $DATA_DIR/scripts/"
+echo "✅ Created: $DATA_DIR/data-quality-checklist.md"
+echo ""
+echo "🎉 Data analysis workspace ready!"
+echo ""
+echo "Quick start:"
+echo "  1. Put data files in data/"
+echo "  2. Store SQL queries in queries/"
+echo "  3. Use scripts/analyze_template.py as starting point"
+echo "  4. Generate reports in reports/"

--- a/skill/data-analyst/scripts/query.sh
+++ b/skill/data-analyst/scripts/query.sh
@@ -1,0 +1,128 @@
+#!/bin/bash
+# query.sh - Quick SQL query execution
+# Usage: ./query.sh [options] [query or --file]
+
+# Configuration - update these for your database
+DB_TYPE="${DB_TYPE:-sqlite}"  # sqlite, postgres, mysql
+DB_CONNECTION="${DB_CONNECTION:-}"
+
+show_help() {
+    echo "SQL Query Tool"
+    echo "=============="
+    echo ""
+    echo "Usage:"
+    echo "  $0 \"SELECT * FROM table\"           - Run inline query"
+    echo "  $0 --file queries/report.sql       - Run query from file"
+    echo "  $0 --file query.sql --output out.csv - Save results to CSV"
+    echo ""
+    echo "Options:"
+    echo "  --file, -f    SQL file to execute"
+    echo "  --output, -o  Output file (CSV)"
+    echo "  --db          Database connection string"
+    echo "  --type        Database type (sqlite, postgres, mysql)"
+    echo ""
+    echo "Environment Variables:"
+    echo "  DB_TYPE       Database type (default: sqlite)"
+    echo "  DB_CONNECTION Database connection string"
+    echo ""
+    echo "Examples:"
+    echo "  DB_CONNECTION='host=localhost dbname=mydb' $0 'SELECT COUNT(*) FROM users'"
+    echo "  $0 --file queries/daily-report.sql --output reports/daily.csv"
+}
+
+run_query() {
+    local query="$1"
+    local output="$2"
+    
+    case "$DB_TYPE" in
+        sqlite)
+            if [ -n "$output" ]; then
+                sqlite3 -header -csv "$DB_CONNECTION" "$query" > "$output"
+            else
+                sqlite3 -header -column "$DB_CONNECTION" "$query"
+            fi
+            ;;
+        postgres|postgresql)
+            if [ -n "$output" ]; then
+                psql "$DB_CONNECTION" -c "COPY ($query) TO STDOUT WITH CSV HEADER" > "$output"
+            else
+                psql "$DB_CONNECTION" -c "$query"
+            fi
+            ;;
+        mysql)
+            if [ -n "$output" ]; then
+                mysql $DB_CONNECTION -e "$query" | sed 's/\t/,/g' > "$output"
+            else
+                mysql $DB_CONNECTION -e "$query"
+            fi
+            ;;
+        *)
+            echo "Unsupported database type: $DB_TYPE"
+            echo "Supported: sqlite, postgres, mysql"
+            exit 1
+            ;;
+    esac
+}
+
+# Parse arguments
+QUERY=""
+FILE=""
+OUTPUT=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --help|-h)
+            show_help
+            exit 0
+            ;;
+        --file|-f)
+            FILE="$2"
+            shift 2
+            ;;
+        --output|-o)
+            OUTPUT="$2"
+            shift 2
+            ;;
+        --db)
+            DB_CONNECTION="$2"
+            shift 2
+            ;;
+        --type)
+            DB_TYPE="$2"
+            shift 2
+            ;;
+        *)
+            QUERY="$1"
+            shift
+            ;;
+    esac
+done
+
+# Get query from file or argument
+if [ -n "$FILE" ]; then
+    if [ ! -f "$FILE" ]; then
+        echo "❌ File not found: $FILE"
+        exit 1
+    fi
+    QUERY=$(cat "$FILE")
+fi
+
+if [ -z "$QUERY" ]; then
+    show_help
+    exit 1
+fi
+
+if [ -z "$DB_CONNECTION" ]; then
+    echo "❌ No database connection configured"
+    echo ""
+    echo "Set DB_CONNECTION environment variable or use --db flag"
+    echo "Example: DB_CONNECTION='mydb.sqlite' $0 'SELECT * FROM users'"
+    exit 1
+fi
+
+echo "🔍 Running query..."
+run_query "$QUERY" "$OUTPUT"
+
+if [ -n "$OUTPUT" ]; then
+    echo "✅ Results saved to: $OUTPUT"
+fi

--- a/skill/duckdb-cli-ai-skills/README.md
+++ b/skill/duckdb-cli-ai-skills/README.md
@@ -1,0 +1,69 @@
+# DuckDB CLI AI Skill
+
+A comprehensive AI skill for [Claude Code](https://claude.ai/code) that provides expert assistance with DuckDB CLI operations.
+
+## What is this?
+
+This is a **skill file** for Claude Code (Anthropic's CLI tool). When activated, it gives Claude deep knowledge about DuckDB CLI, enabling it to help you with:
+
+- SQL queries on CSV, Parquet, and JSON files
+- Data conversion between formats
+- Database operations and analysis
+- Command-line arguments and dot commands
+- Output formatting and configuration
+
+## Installation
+
+### Claude Code (recommended)
+
+Copy `SKILL.md` to your Claude Code skills directory:
+
+```bash
+mkdir -p ~/.claude/skills/duckdb
+cp SKILL.md ~/.claude/skills/duckdb/
+```
+
+Then use `/duckdb` in Claude Code to activate the skill.
+
+### Other AI Tools
+
+The `SKILL.md` file follows standard markdown conventions and can be adapted for use with other AI assistants that support custom instructions or system prompts.
+
+## What's Included
+
+The skill covers all official DuckDB CLI documentation:
+
+- **Quick Start** - Read files directly with SQL
+- **Command Line Arguments** - All flags and options
+- **Data Conversion** - CSV, Parquet, JSON transformations
+- **Dot Commands** - Schema inspection, output control
+- **Output Formats** - All 18 available formats
+- **Keyboard Shortcuts** - Navigation, history, editing
+- **Autocomplete** - Context-aware completion
+- **Configuration** - ~/.duckdbrc settings
+- **Safe Mode** - Restricted file access mode
+
+## Example Usage
+
+Once the skill is activated, you can ask Claude things like:
+
+- "Convert this CSV to Parquet"
+- "Show me statistics for sales.csv"
+- "Join these two files on customer_id"
+- "What's the DuckDB command to export as JSON?"
+
+## Documentation Sources
+
+Based on official DuckDB documentation:
+- [CLI Overview](https://duckdb.org/docs/stable/clients/cli/overview)
+- [Arguments](https://duckdb.org/docs/stable/clients/cli/arguments)
+- [Dot Commands](https://duckdb.org/docs/stable/clients/cli/dot_commands)
+- [Output Formats](https://duckdb.org/docs/stable/clients/cli/output_formats)
+- [Editing](https://duckdb.org/docs/stable/clients/cli/editing)
+- [Autocomplete](https://duckdb.org/docs/stable/clients/cli/autocomplete)
+- [Syntax Highlighting](https://duckdb.org/docs/stable/clients/cli/syntax_highlighting)
+- [Safe Mode](https://duckdb.org/docs/stable/clients/cli/safe_mode)
+
+## License
+
+MIT

--- a/skill/duckdb-cli-ai-skills/SKILL.md
+++ b/skill/duckdb-cli-ai-skills/SKILL.md
@@ -1,0 +1,280 @@
+---
+name: duckdb-en
+description: DuckDB CLI specialist for SQL analysis, data processing and file conversion. Use for SQL queries, CSV/Parquet/JSON analysis, database queries, or data conversion. Triggers on "duckdb", "sql", "query", "data analysis", "parquet", "convert data".
+---
+
+# DuckDB CLI Specialist
+
+Helps with data analysis, SQL queries and file conversion via DuckDB CLI.
+
+## Quick Start
+
+### Read data files directly with SQL
+```bash
+# CSV
+duckdb -c "SELECT * FROM 'data.csv' LIMIT 10"
+
+# Parquet
+duckdb -c "SELECT * FROM 'data.parquet'"
+
+# Multiple files with glob
+duckdb -c "SELECT * FROM read_parquet('logs/*.parquet')"
+
+# JSON
+duckdb -c "SELECT * FROM read_json_auto('data.json')"
+```
+
+### Open persistent databases
+```bash
+# Create/open database
+duckdb my_database.duckdb
+
+# Read-only mode
+duckdb -readonly existing.duckdb
+```
+
+## Command Line Arguments
+
+### Output formats (as flags)
+| Flag | Format |
+|------|--------|
+| `-csv` | Comma-separated |
+| `-json` | JSON array |
+| `-table` | ASCII table |
+| `-markdown` | Markdown table |
+| `-html` | HTML table |
+| `-line` | One value per line |
+
+### Execution arguments
+| Argument | Description |
+|----------|-------------|
+| `-c COMMAND` | Run SQL and exit |
+| `-f FILENAME` | Run script from file |
+| `-init FILE` | Use alternative to ~/.duckdbrc |
+| `-readonly` | Open in read-only mode |
+| `-echo` | Show commands before execution |
+| `-bail` | Stop on first error |
+| `-header` / `-noheader` | Show/hide column headers |
+| `-nullvalue TEXT` | Text for NULL values |
+| `-separator SEP` | Column separator |
+
+## Data Conversion
+
+### CSV to Parquet
+```bash
+duckdb -c "COPY (SELECT * FROM 'input.csv') TO 'output.parquet' (FORMAT PARQUET)"
+```
+
+### Parquet to CSV
+```bash
+duckdb -c "COPY (SELECT * FROM 'input.parquet') TO 'output.csv' (HEADER, DELIMITER ',')"
+```
+
+### JSON to Parquet
+```bash
+duckdb -c "COPY (SELECT * FROM read_json_auto('input.json')) TO 'output.parquet' (FORMAT PARQUET)"
+```
+
+### Convert with filtering
+```bash
+duckdb -c "COPY (SELECT * FROM 'data.csv' WHERE amount > 1000) TO 'filtered.parquet' (FORMAT PARQUET)"
+```
+
+## Dot Commands
+
+### Schema inspection
+| Command | Description |
+|---------|-------------|
+| `.tables [pattern]` | Show tables (with LIKE pattern) |
+| `.schema [table]` | Show CREATE statements |
+| `.databases` | Show attached databases |
+
+### Output control
+| Command | Description |
+|---------|-------------|
+| `.mode FORMAT` | Change output format |
+| `.output file` | Send output to file |
+| `.once file` | Next output to file |
+| `.headers on/off` | Show/hide column headers |
+| `.separator COL ROW` | Set separators |
+
+### Queries
+| Command | Description |
+|---------|-------------|
+| `.timer on/off` | Show execution time |
+| `.echo on/off` | Show commands before execution |
+| `.bail on/off` | Stop on error |
+| `.read file.sql` | Run SQL from file |
+
+### Editing
+| Command | Description |
+|---------|-------------|
+| `.edit` or `\e` | Open query in external editor |
+| `.help [pattern]` | Show help |
+
+## Output Formats (18 available)
+
+### Data export
+- **csv** - Comma-separated for spreadsheets
+- **tabs** - Tab-separated
+- **json** - JSON array
+- **jsonlines** - Newline-delimited JSON (streaming)
+
+### Readable formats
+- **duckbox** (default) - Pretty ASCII with unicode box-drawing
+- **table** - Simple ASCII table
+- **markdown** - For documentation
+- **html** - HTML table
+- **latex** - For academic papers
+
+### Specialized
+- **insert TABLE** - SQL INSERT statements
+- **column** - Columns with adjustable width
+- **line** - One value per line
+- **list** - Pipe-separated
+- **trash** - Discard output
+
+## Keyboard Shortcuts (macOS/Linux)
+
+### Navigation
+| Shortcut | Action |
+|----------|--------|
+| `Home` / `End` | Start/end of line |
+| `Ctrl+Left/Right` | Jump word |
+| `Ctrl+A` / `Ctrl+E` | Start/end of buffer |
+
+### History
+| Shortcut | Action |
+|----------|--------|
+| `Ctrl+P` / `Ctrl+N` | Previous/next command |
+| `Ctrl+R` | Search history |
+| `Alt+<` / `Alt+>` | First/last in history |
+
+### Editing
+| Shortcut | Action |
+|----------|--------|
+| `Ctrl+W` | Delete word backward |
+| `Alt+D` | Delete word forward |
+| `Alt+U` / `Alt+L` | Uppercase/lowercase word |
+| `Ctrl+K` | Delete to end of line |
+
+### Autocomplete
+| Shortcut | Action |
+|----------|--------|
+| `Tab` | Autocomplete / next suggestion |
+| `Shift+Tab` | Previous suggestion |
+| `Esc+Esc` | Undo autocomplete |
+
+## Autocomplete
+
+Context-aware autocomplete activated with `Tab`:
+- **Keywords** - SQL commands
+- **Table names** - Database objects
+- **Column names** - Fields and functions
+- **File names** - Path completion
+
+## Database Operations
+
+### Create table from file
+```sql
+CREATE TABLE sales AS SELECT * FROM 'sales_2024.csv';
+```
+
+### Insert data
+```sql
+INSERT INTO sales SELECT * FROM 'sales_2025.csv';
+```
+
+### Export table
+```sql
+COPY sales TO 'backup.parquet' (FORMAT PARQUET);
+```
+
+## Analysis Examples
+
+### Quick statistics
+```sql
+SELECT
+    COUNT(*) as count,
+    AVG(amount) as average,
+    SUM(amount) as total
+FROM 'transactions.csv';
+```
+
+### Grouping
+```sql
+SELECT
+    category,
+    COUNT(*) as count,
+    SUM(amount) as total
+FROM 'data.csv'
+GROUP BY category
+ORDER BY total DESC;
+```
+
+### Join on files
+```sql
+SELECT a.*, b.name
+FROM 'orders.csv' a
+JOIN 'customers.parquet' b ON a.customer_id = b.id;
+```
+
+### Describe data
+```sql
+DESCRIBE SELECT * FROM 'data.csv';
+```
+
+## Pipe and stdin
+
+```bash
+# Read from stdin
+cat data.csv | duckdb -c "SELECT * FROM read_csv('/dev/stdin')"
+
+# Pipe to another command
+duckdb -csv -c "SELECT * FROM 'data.parquet'" | head -20
+
+# Write to stdout
+duckdb -c "COPY (SELECT * FROM 'data.csv') TO '/dev/stdout' (FORMAT CSV)"
+```
+
+## Configuration
+
+Save common settings in `~/.duckdbrc`:
+```sql
+.timer on
+.mode duckbox
+.maxrows 50
+.highlight on
+```
+
+### Syntax highlighting colors
+```sql
+.keyword green
+.constant yellow
+.comment brightblack
+.error red
+```
+
+## External Editor
+
+Open complex queries in your editor:
+```sql
+.edit
+```
+
+Editor is chosen from: `DUCKDB_EDITOR` → `EDITOR` → `VISUAL` → `vi`
+
+## Safe Mode
+
+Secure mode that restricts file access. When enabled:
+- No external file access
+- Disables `.read`, `.output`, `.import`, `.sh` etc.
+- **Cannot** be disabled in the same session
+
+## Tips
+
+- Use `LIMIT` on large files for quick preview
+- Parquet is faster than CSV for repeated queries
+- `read_csv_auto` and `read_json_auto` guess column types
+- Arguments are processed in order (like SQLite CLI)
+- WSL2 may show incorrect `memory_limit` values on some Ubuntu versions

--- a/skill/duckdb-cli-ai-skills/_meta.json
+++ b/skill/duckdb-cli-ai-skills/_meta.json
@@ -1,0 +1,6 @@
+{
+  "ownerId": "kn722te0hedhg7q4jjpa9sv3jx7zv1gn",
+  "slug": "duckdb-cli-ai-skills",
+  "version": "1.0.0",
+  "publishedAt": 1769247814673
+}

--- a/skill/mcporter/SKILL.md
+++ b/skill/mcporter/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: mcporter
+description: Use the mcporter CLI to list, configure, auth, and call MCP servers/tools directly (HTTP or stdio), including ad-hoc servers, config edits, and CLI/type generation.
+homepage: http://mcporter.dev
+metadata: {"clawdbot":{"emoji":"📦","requires":{"bins":["mcporter"]},"install":[{"id":"node","kind":"node","package":"mcporter","bins":["mcporter"],"label":"Install mcporter (node)"}]}}
+---
+
+# mcporter
+
+Use `mcporter` to work with MCP servers directly.
+
+Quick start
+- `mcporter list`
+- `mcporter list <server> --schema`
+- `mcporter call <server.tool> key=value`
+
+Call tools
+- Selector: `mcporter call linear.list_issues team=ENG limit:5`
+- Function syntax: `mcporter call "linear.create_issue(title: \"Bug\")"`
+- Full URL: `mcporter call https://api.example.com/mcp.fetch url:https://example.com`
+- Stdio: `mcporter call --stdio "bun run ./server.ts" scrape url=https://example.com`
+- JSON payload: `mcporter call <server.tool> --args '{"limit":5}'`
+
+Auth + config
+- OAuth: `mcporter auth <server | url> [--reset]`
+- Config: `mcporter config list|get|add|remove|import|login|logout`
+
+Daemon
+- `mcporter daemon start|status|stop|restart`
+
+Codegen
+- CLI: `mcporter generate-cli --server <name>` or `--command <url>`
+- Inspect: `mcporter inspect-cli <path> [--json]`
+- TS: `mcporter emit-ts <server> --mode client|types`
+
+Notes
+- Config default: `./config/mcporter.json` (override with `--config`).
+- Prefer `--output json` for machine-readable results.

--- a/skill/mcporter/_meta.json
+++ b/skill/mcporter/_meta.json
@@ -1,0 +1,6 @@
+{
+  "ownerId": "kn70pywhg0fyz996kpa8xj89s57yhv26",
+  "slug": "mcporter",
+  "version": "1.0.0",
+  "publishedAt": 1767545355897
+}

--- a/skill/self-improving-agent/.learnings/ERRORS.md
+++ b/skill/self-improving-agent/.learnings/ERRORS.md
@@ -1,0 +1,5 @@
+# Errors Log
+
+Command failures, exceptions, and unexpected behaviors.
+
+---

--- a/skill/self-improving-agent/.learnings/FEATURE_REQUESTS.md
+++ b/skill/self-improving-agent/.learnings/FEATURE_REQUESTS.md
@@ -1,0 +1,5 @@
+# Feature Requests
+
+Capabilities requested by user that don't currently exist.
+
+---

--- a/skill/self-improving-agent/.learnings/LEARNINGS.md
+++ b/skill/self-improving-agent/.learnings/LEARNINGS.md
@@ -1,0 +1,5 @@
+# Learnings Log
+
+Captured learnings, corrections, and discoveries. Review before major tasks.
+
+---

--- a/skill/self-improving-agent/SKILL.md
+++ b/skill/self-improving-agent/SKILL.md
@@ -1,0 +1,647 @@
+---
+name: self-improvement
+description: "Captures learnings, errors, and corrections to enable continuous improvement. Use when: (1) A command or operation fails unexpectedly, (2) User corrects Claude ('No, that's wrong...', 'Actually...'), (3) User requests a capability that doesn't exist, (4) An external API or tool fails, (5) Claude realizes its knowledge is outdated or incorrect, (6) A better approach is discovered for a recurring task. Also review learnings before major tasks."
+metadata:
+---
+
+# Self-Improvement Skill
+
+Log learnings and errors to markdown files for continuous improvement. Coding agents can later process these into fixes, and important learnings get promoted to project memory.
+
+## Quick Reference
+
+| Situation | Action |
+|-----------|--------|
+| Command/operation fails | Log to `.learnings/ERRORS.md` |
+| User corrects you | Log to `.learnings/LEARNINGS.md` with category `correction` |
+| User wants missing feature | Log to `.learnings/FEATURE_REQUESTS.md` |
+| API/external tool fails | Log to `.learnings/ERRORS.md` with integration details |
+| Knowledge was outdated | Log to `.learnings/LEARNINGS.md` with category `knowledge_gap` |
+| Found better approach | Log to `.learnings/LEARNINGS.md` with category `best_practice` |
+| Simplify/Harden recurring patterns | Log/update `.learnings/LEARNINGS.md` with `Source: simplify-and-harden` and a stable `Pattern-Key` |
+| Similar to existing entry | Link with `**See Also**`, consider priority bump |
+| Broadly applicable learning | Promote to `CLAUDE.md`, `AGENTS.md`, and/or `.github/copilot-instructions.md` |
+| Workflow improvements | Promote to `AGENTS.md` (OpenClaw workspace) |
+| Tool gotchas | Promote to `TOOLS.md` (OpenClaw workspace) |
+| Behavioral patterns | Promote to `SOUL.md` (OpenClaw workspace) |
+
+## OpenClaw Setup (Recommended)
+
+OpenClaw is the primary platform for this skill. It uses workspace-based prompt injection with automatic skill loading.
+
+### Installation
+
+**Via ClawdHub (recommended):**
+```bash
+clawdhub install self-improving-agent
+```
+
+**Manual:**
+```bash
+git clone https://github.com/peterskoett/self-improving-agent.git ~/.openclaw/skills/self-improving-agent
+```
+
+Remade for openclaw from original repo : https://github.com/pskoett/pskoett-ai-skills - https://github.com/pskoett/pskoett-ai-skills/tree/main/skills/self-improvement
+
+### Workspace Structure
+
+OpenClaw injects these files into every session:
+
+```
+~/.openclaw/workspace/
+├── AGENTS.md          # Multi-agent workflows, delegation patterns
+├── SOUL.md            # Behavioral guidelines, personality, principles
+├── TOOLS.md           # Tool capabilities, integration gotchas
+├── MEMORY.md          # Long-term memory (main session only)
+├── memory/            # Daily memory files
+│   └── YYYY-MM-DD.md
+└── .learnings/        # This skill's log files
+    ├── LEARNINGS.md
+    ├── ERRORS.md
+    └── FEATURE_REQUESTS.md
+```
+
+### Create Learning Files
+
+```bash
+mkdir -p ~/.openclaw/workspace/.learnings
+```
+
+Then create the log files (or copy from `assets/`):
+- `LEARNINGS.md` — corrections, knowledge gaps, best practices
+- `ERRORS.md` — command failures, exceptions
+- `FEATURE_REQUESTS.md` — user-requested capabilities
+
+### Promotion Targets
+
+When learnings prove broadly applicable, promote them to workspace files:
+
+| Learning Type | Promote To | Example |
+|---------------|------------|---------|
+| Behavioral patterns | `SOUL.md` | "Be concise, avoid disclaimers" |
+| Workflow improvements | `AGENTS.md` | "Spawn sub-agents for long tasks" |
+| Tool gotchas | `TOOLS.md` | "Git push needs auth configured first" |
+
+### Inter-Session Communication
+
+OpenClaw provides tools to share learnings across sessions:
+
+- **sessions_list** — View active/recent sessions
+- **sessions_history** — Read another session's transcript  
+- **sessions_send** — Send a learning to another session
+- **sessions_spawn** — Spawn a sub-agent for background work
+
+### Optional: Enable Hook
+
+For automatic reminders at session start:
+
+```bash
+# Copy hook to OpenClaw hooks directory
+cp -r hooks/openclaw ~/.openclaw/hooks/self-improvement
+
+# Enable it
+openclaw hooks enable self-improvement
+```
+
+See `references/openclaw-integration.md` for complete details.
+
+---
+
+## Generic Setup (Other Agents)
+
+For Claude Code, Codex, Copilot, or other agents, create `.learnings/` in your project:
+
+```bash
+mkdir -p .learnings
+```
+
+Copy templates from `assets/` or create files with headers.
+
+### Add reference to agent files AGENTS.md, CLAUDE.md, or .github/copilot-instructions.md to remind yourself to log learnings. (this is an alternative to hook-based reminders)
+
+#### Self-Improvement Workflow
+
+When errors or corrections occur:
+1. Log to `.learnings/ERRORS.md`, `LEARNINGS.md`, or `FEATURE_REQUESTS.md`
+2. Review and promote broadly applicable learnings to:
+   - `CLAUDE.md` - project facts and conventions
+   - `AGENTS.md` - workflows and automation
+   - `.github/copilot-instructions.md` - Copilot context
+
+## Logging Format
+
+### Learning Entry
+
+Append to `.learnings/LEARNINGS.md`:
+
+```markdown
+## [LRN-YYYYMMDD-XXX] category
+
+**Logged**: ISO-8601 timestamp
+**Priority**: low | medium | high | critical
+**Status**: pending
+**Area**: frontend | backend | infra | tests | docs | config
+
+### Summary
+One-line description of what was learned
+
+### Details
+Full context: what happened, what was wrong, what's correct
+
+### Suggested Action
+Specific fix or improvement to make
+
+### Metadata
+- Source: conversation | error | user_feedback
+- Related Files: path/to/file.ext
+- Tags: tag1, tag2
+- See Also: LRN-20250110-001 (if related to existing entry)
+- Pattern-Key: simplify.dead_code | harden.input_validation (optional, for recurring-pattern tracking)
+- Recurrence-Count: 1 (optional)
+- First-Seen: 2025-01-15 (optional)
+- Last-Seen: 2025-01-15 (optional)
+
+---
+```
+
+### Error Entry
+
+Append to `.learnings/ERRORS.md`:
+
+```markdown
+## [ERR-YYYYMMDD-XXX] skill_or_command_name
+
+**Logged**: ISO-8601 timestamp
+**Priority**: high
+**Status**: pending
+**Area**: frontend | backend | infra | tests | docs | config
+
+### Summary
+Brief description of what failed
+
+### Error
+```
+Actual error message or output
+```
+
+### Context
+- Command/operation attempted
+- Input or parameters used
+- Environment details if relevant
+
+### Suggested Fix
+If identifiable, what might resolve this
+
+### Metadata
+- Reproducible: yes | no | unknown
+- Related Files: path/to/file.ext
+- See Also: ERR-20250110-001 (if recurring)
+
+---
+```
+
+### Feature Request Entry
+
+Append to `.learnings/FEATURE_REQUESTS.md`:
+
+```markdown
+## [FEAT-YYYYMMDD-XXX] capability_name
+
+**Logged**: ISO-8601 timestamp
+**Priority**: medium
+**Status**: pending
+**Area**: frontend | backend | infra | tests | docs | config
+
+### Requested Capability
+What the user wanted to do
+
+### User Context
+Why they needed it, what problem they're solving
+
+### Complexity Estimate
+simple | medium | complex
+
+### Suggested Implementation
+How this could be built, what it might extend
+
+### Metadata
+- Frequency: first_time | recurring
+- Related Features: existing_feature_name
+
+---
+```
+
+## ID Generation
+
+Format: `TYPE-YYYYMMDD-XXX`
+- TYPE: `LRN` (learning), `ERR` (error), `FEAT` (feature)
+- YYYYMMDD: Current date
+- XXX: Sequential number or random 3 chars (e.g., `001`, `A7B`)
+
+Examples: `LRN-20250115-001`, `ERR-20250115-A3F`, `FEAT-20250115-002`
+
+## Resolving Entries
+
+When an issue is fixed, update the entry:
+
+1. Change `**Status**: pending` → `**Status**: resolved`
+2. Add resolution block after Metadata:
+
+```markdown
+### Resolution
+- **Resolved**: 2025-01-16T09:00:00Z
+- **Commit/PR**: abc123 or #42
+- **Notes**: Brief description of what was done
+```
+
+Other status values:
+- `in_progress` - Actively being worked on
+- `wont_fix` - Decided not to address (add reason in Resolution notes)
+- `promoted` - Elevated to CLAUDE.md, AGENTS.md, or .github/copilot-instructions.md
+
+## Promoting to Project Memory
+
+When a learning is broadly applicable (not a one-off fix), promote it to permanent project memory.
+
+### When to Promote
+
+- Learning applies across multiple files/features
+- Knowledge any contributor (human or AI) should know
+- Prevents recurring mistakes
+- Documents project-specific conventions
+
+### Promotion Targets
+
+| Target | What Belongs There |
+|--------|-------------------|
+| `CLAUDE.md` | Project facts, conventions, gotchas for all Claude interactions |
+| `AGENTS.md` | Agent-specific workflows, tool usage patterns, automation rules |
+| `.github/copilot-instructions.md` | Project context and conventions for GitHub Copilot |
+| `SOUL.md` | Behavioral guidelines, communication style, principles (OpenClaw workspace) |
+| `TOOLS.md` | Tool capabilities, usage patterns, integration gotchas (OpenClaw workspace) |
+
+### How to Promote
+
+1. **Distill** the learning into a concise rule or fact
+2. **Add** to appropriate section in target file (create file if needed)
+3. **Update** original entry:
+   - Change `**Status**: pending` → `**Status**: promoted`
+   - Add `**Promoted**: CLAUDE.md`, `AGENTS.md`, or `.github/copilot-instructions.md`
+
+### Promotion Examples
+
+**Learning** (verbose):
+> Project uses pnpm workspaces. Attempted `npm install` but failed. 
+> Lock file is `pnpm-lock.yaml`. Must use `pnpm install`.
+
+**In CLAUDE.md** (concise):
+```markdown
+## Build & Dependencies
+- Package manager: pnpm (not npm) - use `pnpm install`
+```
+
+**Learning** (verbose):
+> When modifying API endpoints, must regenerate TypeScript client.
+> Forgetting this causes type mismatches at runtime.
+
+**In AGENTS.md** (actionable):
+```markdown
+## After API Changes
+1. Regenerate client: `pnpm run generate:api`
+2. Check for type errors: `pnpm tsc --noEmit`
+```
+
+## Recurring Pattern Detection
+
+If logging something similar to an existing entry:
+
+1. **Search first**: `grep -r "keyword" .learnings/`
+2. **Link entries**: Add `**See Also**: ERR-20250110-001` in Metadata
+3. **Bump priority** if issue keeps recurring
+4. **Consider systemic fix**: Recurring issues often indicate:
+   - Missing documentation (→ promote to CLAUDE.md or .github/copilot-instructions.md)
+   - Missing automation (→ add to AGENTS.md)
+   - Architectural problem (→ create tech debt ticket)
+
+## Simplify & Harden Feed
+
+Use this workflow to ingest recurring patterns from the `simplify-and-harden`
+skill and turn them into durable prompt guidance.
+
+### Ingestion Workflow
+
+1. Read `simplify_and_harden.learning_loop.candidates` from the task summary.
+2. For each candidate, use `pattern_key` as the stable dedupe key.
+3. Search `.learnings/LEARNINGS.md` for an existing entry with that key:
+   - `grep -n "Pattern-Key: <pattern_key>" .learnings/LEARNINGS.md`
+4. If found:
+   - Increment `Recurrence-Count`
+   - Update `Last-Seen`
+   - Add `See Also` links to related entries/tasks
+5. If not found:
+   - Create a new `LRN-...` entry
+   - Set `Source: simplify-and-harden`
+   - Set `Pattern-Key`, `Recurrence-Count: 1`, and `First-Seen`/`Last-Seen`
+
+### Promotion Rule (System Prompt Feedback)
+
+Promote recurring patterns into agent context/system prompt files when all are true:
+
+- `Recurrence-Count >= 3`
+- Seen across at least 2 distinct tasks
+- Occurred within a 30-day window
+
+Promotion targets:
+- `CLAUDE.md`
+- `AGENTS.md`
+- `.github/copilot-instructions.md`
+- `SOUL.md` / `TOOLS.md` for OpenClaw workspace-level guidance when applicable
+
+Write promoted rules as short prevention rules (what to do before/while coding),
+not long incident write-ups.
+
+## Periodic Review
+
+Review `.learnings/` at natural breakpoints:
+
+### When to Review
+- Before starting a new major task
+- After completing a feature
+- When working in an area with past learnings
+- Weekly during active development
+
+### Quick Status Check
+```bash
+# Count pending items
+grep -h "Status\*\*: pending" .learnings/*.md | wc -l
+
+# List pending high-priority items
+grep -B5 "Priority\*\*: high" .learnings/*.md | grep "^## \["
+
+# Find learnings for a specific area
+grep -l "Area\*\*: backend" .learnings/*.md
+```
+
+### Review Actions
+- Resolve fixed items
+- Promote applicable learnings
+- Link related entries
+- Escalate recurring issues
+
+## Detection Triggers
+
+Automatically log when you notice:
+
+**Corrections** (→ learning with `correction` category):
+- "No, that's not right..."
+- "Actually, it should be..."
+- "You're wrong about..."
+- "That's outdated..."
+
+**Feature Requests** (→ feature request):
+- "Can you also..."
+- "I wish you could..."
+- "Is there a way to..."
+- "Why can't you..."
+
+**Knowledge Gaps** (→ learning with `knowledge_gap` category):
+- User provides information you didn't know
+- Documentation you referenced is outdated
+- API behavior differs from your understanding
+
+**Errors** (→ error entry):
+- Command returns non-zero exit code
+- Exception or stack trace
+- Unexpected output or behavior
+- Timeout or connection failure
+
+## Priority Guidelines
+
+| Priority | When to Use |
+|----------|-------------|
+| `critical` | Blocks core functionality, data loss risk, security issue |
+| `high` | Significant impact, affects common workflows, recurring issue |
+| `medium` | Moderate impact, workaround exists |
+| `low` | Minor inconvenience, edge case, nice-to-have |
+
+## Area Tags
+
+Use to filter learnings by codebase region:
+
+| Area | Scope |
+|------|-------|
+| `frontend` | UI, components, client-side code |
+| `backend` | API, services, server-side code |
+| `infra` | CI/CD, deployment, Docker, cloud |
+| `tests` | Test files, testing utilities, coverage |
+| `docs` | Documentation, comments, READMEs |
+| `config` | Configuration files, environment, settings |
+
+## Best Practices
+
+1. **Log immediately** - context is freshest right after the issue
+2. **Be specific** - future agents need to understand quickly
+3. **Include reproduction steps** - especially for errors
+4. **Link related files** - makes fixes easier
+5. **Suggest concrete fixes** - not just "investigate"
+6. **Use consistent categories** - enables filtering
+7. **Promote aggressively** - if in doubt, add to CLAUDE.md or .github/copilot-instructions.md
+8. **Review regularly** - stale learnings lose value
+
+## Gitignore Options
+
+**Keep learnings local** (per-developer):
+```gitignore
+.learnings/
+```
+
+**Track learnings in repo** (team-wide):
+Don't add to .gitignore - learnings become shared knowledge.
+
+**Hybrid** (track templates, ignore entries):
+```gitignore
+.learnings/*.md
+!.learnings/.gitkeep
+```
+
+## Hook Integration
+
+Enable automatic reminders through agent hooks. This is **opt-in** - you must explicitly configure hooks.
+
+### Quick Setup (Claude Code / Codex)
+
+Create `.claude/settings.json` in your project:
+
+```json
+{
+  "hooks": {
+    "UserPromptSubmit": [{
+      "matcher": "",
+      "hooks": [{
+        "type": "command",
+        "command": "./skills/self-improvement/scripts/activator.sh"
+      }]
+    }]
+  }
+}
+```
+
+This injects a learning evaluation reminder after each prompt (~50-100 tokens overhead).
+
+### Full Setup (With Error Detection)
+
+```json
+{
+  "hooks": {
+    "UserPromptSubmit": [{
+      "matcher": "",
+      "hooks": [{
+        "type": "command",
+        "command": "./skills/self-improvement/scripts/activator.sh"
+      }]
+    }],
+    "PostToolUse": [{
+      "matcher": "Bash",
+      "hooks": [{
+        "type": "command",
+        "command": "./skills/self-improvement/scripts/error-detector.sh"
+      }]
+    }]
+  }
+}
+```
+
+### Available Hook Scripts
+
+| Script | Hook Type | Purpose |
+|--------|-----------|---------|
+| `scripts/activator.sh` | UserPromptSubmit | Reminds to evaluate learnings after tasks |
+| `scripts/error-detector.sh` | PostToolUse (Bash) | Triggers on command errors |
+
+See `references/hooks-setup.md` for detailed configuration and troubleshooting.
+
+## Automatic Skill Extraction
+
+When a learning is valuable enough to become a reusable skill, extract it using the provided helper.
+
+### Skill Extraction Criteria
+
+A learning qualifies for skill extraction when ANY of these apply:
+
+| Criterion | Description |
+|-----------|-------------|
+| **Recurring** | Has `See Also` links to 2+ similar issues |
+| **Verified** | Status is `resolved` with working fix |
+| **Non-obvious** | Required actual debugging/investigation to discover |
+| **Broadly applicable** | Not project-specific; useful across codebases |
+| **User-flagged** | User says "save this as a skill" or similar |
+
+### Extraction Workflow
+
+1. **Identify candidate**: Learning meets extraction criteria
+2. **Run helper** (or create manually):
+   ```bash
+   ./skills/self-improvement/scripts/extract-skill.sh skill-name --dry-run
+   ./skills/self-improvement/scripts/extract-skill.sh skill-name
+   ```
+3. **Customize SKILL.md**: Fill in template with learning content
+4. **Update learning**: Set status to `promoted_to_skill`, add `Skill-Path`
+5. **Verify**: Read skill in fresh session to ensure it's self-contained
+
+### Manual Extraction
+
+If you prefer manual creation:
+
+1. Create `skills/<skill-name>/SKILL.md`
+2. Use template from `assets/SKILL-TEMPLATE.md`
+3. Follow [Agent Skills spec](https://agentskills.io/specification):
+   - YAML frontmatter with `name` and `description`
+   - Name must match folder name
+   - No README.md inside skill folder
+
+### Extraction Detection Triggers
+
+Watch for these signals that a learning should become a skill:
+
+**In conversation:**
+- "Save this as a skill"
+- "I keep running into this"
+- "This would be useful for other projects"
+- "Remember this pattern"
+
+**In learning entries:**
+- Multiple `See Also` links (recurring issue)
+- High priority + resolved status
+- Category: `best_practice` with broad applicability
+- User feedback praising the solution
+
+### Skill Quality Gates
+
+Before extraction, verify:
+
+- [ ] Solution is tested and working
+- [ ] Description is clear without original context
+- [ ] Code examples are self-contained
+- [ ] No project-specific hardcoded values
+- [ ] Follows skill naming conventions (lowercase, hyphens)
+
+## Multi-Agent Support
+
+This skill works across different AI coding agents with agent-specific activation.
+
+### Claude Code
+
+**Activation**: Hooks (UserPromptSubmit, PostToolUse)
+**Setup**: `.claude/settings.json` with hook configuration
+**Detection**: Automatic via hook scripts
+
+### Codex CLI
+
+**Activation**: Hooks (same pattern as Claude Code)
+**Setup**: `.codex/settings.json` with hook configuration
+**Detection**: Automatic via hook scripts
+
+### GitHub Copilot
+
+**Activation**: Manual (no hook support)
+**Setup**: Add to `.github/copilot-instructions.md`:
+
+```markdown
+## Self-Improvement
+
+After solving non-obvious issues, consider logging to `.learnings/`:
+1. Use format from self-improvement skill
+2. Link related entries with See Also
+3. Promote high-value learnings to skills
+
+Ask in chat: "Should I log this as a learning?"
+```
+
+**Detection**: Manual review at session end
+
+### OpenClaw
+
+**Activation**: Workspace injection + inter-agent messaging
+**Setup**: See "OpenClaw Setup" section above
+**Detection**: Via session tools and workspace files
+
+### Agent-Agnostic Guidance
+
+Regardless of agent, apply self-improvement when you:
+
+1. **Discover something non-obvious** - solution wasn't immediate
+2. **Correct yourself** - initial approach was wrong
+3. **Learn project conventions** - discovered undocumented patterns
+4. **Hit unexpected errors** - especially if diagnosis was difficult
+5. **Find better approaches** - improved on your original solution
+
+### Copilot Chat Integration
+
+For Copilot users, add this to your prompts when relevant:
+
+> After completing this task, evaluate if any learnings should be logged to `.learnings/` using the self-improvement skill format.
+
+Or use quick prompts:
+- "Log this to learnings"
+- "Create a skill from this solution"
+- "Check .learnings/ for related issues"

--- a/skill/self-improving-agent/_meta.json
+++ b/skill/self-improving-agent/_meta.json
@@ -1,0 +1,6 @@
+{
+  "ownerId": "kn70cjr952qdec1nx70zs6wefn7ynq2t",
+  "slug": "self-improving-agent",
+  "version": "3.0.5",
+  "publishedAt": 1773760428300
+}

--- a/skill/self-improving-agent/assets/LEARNINGS.md
+++ b/skill/self-improving-agent/assets/LEARNINGS.md
@@ -1,0 +1,45 @@
+# Learnings
+
+Corrections, insights, and knowledge gaps captured during development.
+
+**Categories**: correction | insight | knowledge_gap | best_practice
+**Areas**: frontend | backend | infra | tests | docs | config
+**Statuses**: pending | in_progress | resolved | wont_fix | promoted | promoted_to_skill
+
+## Status Definitions
+
+| Status | Meaning |
+|--------|---------|
+| `pending` | Not yet addressed |
+| `in_progress` | Actively being worked on |
+| `resolved` | Issue fixed or knowledge integrated |
+| `wont_fix` | Decided not to address (reason in Resolution) |
+| `promoted` | Elevated to CLAUDE.md, AGENTS.md, or copilot-instructions.md |
+| `promoted_to_skill` | Extracted as a reusable skill |
+
+## Skill Extraction Fields
+
+When a learning is promoted to a skill, add these fields:
+
+```markdown
+**Status**: promoted_to_skill
+**Skill-Path**: skills/skill-name
+```
+
+Example:
+```markdown
+## [LRN-20250115-001] best_practice
+
+**Logged**: 2025-01-15T10:00:00Z
+**Priority**: high
+**Status**: promoted_to_skill
+**Skill-Path**: skills/docker-m1-fixes
+**Area**: infra
+
+### Summary
+Docker build fails on Apple Silicon due to platform mismatch
+...
+```
+
+---
+

--- a/skill/self-improving-agent/assets/SKILL-TEMPLATE.md
+++ b/skill/self-improving-agent/assets/SKILL-TEMPLATE.md
@@ -1,0 +1,177 @@
+# Skill Template
+
+Template for creating skills extracted from learnings. Copy and customize.
+
+---
+
+## SKILL.md Template
+
+```markdown
+---
+name: skill-name-here
+description: "Concise description of when and why to use this skill. Include trigger conditions."
+---
+
+# Skill Name
+
+Brief introduction explaining the problem this skill solves and its origin.
+
+## Quick Reference
+
+| Situation | Action |
+|-----------|--------|
+| [Trigger 1] | [Action 1] |
+| [Trigger 2] | [Action 2] |
+
+## Background
+
+Why this knowledge matters. What problems it prevents. Context from the original learning.
+
+## Solution
+
+### Step-by-Step
+
+1. First step with code or command
+2. Second step
+3. Verification step
+
+### Code Example
+
+\`\`\`language
+// Example code demonstrating the solution
+\`\`\`
+
+## Common Variations
+
+- **Variation A**: Description and how to handle
+- **Variation B**: Description and how to handle
+
+## Gotchas
+
+- Warning or common mistake #1
+- Warning or common mistake #2
+
+## Related
+
+- Link to related documentation
+- Link to related skill
+
+## Source
+
+Extracted from learning entry.
+- **Learning ID**: LRN-YYYYMMDD-XXX
+- **Original Category**: correction | insight | knowledge_gap | best_practice
+- **Extraction Date**: YYYY-MM-DD
+```
+
+---
+
+## Minimal Template
+
+For simple skills that don't need all sections:
+
+```markdown
+---
+name: skill-name-here
+description: "What this skill does and when to use it."
+---
+
+# Skill Name
+
+[Problem statement in one sentence]
+
+## Solution
+
+[Direct solution with code/commands]
+
+## Source
+
+- Learning ID: LRN-YYYYMMDD-XXX
+```
+
+---
+
+## Template with Scripts
+
+For skills that include executable helpers:
+
+```markdown
+---
+name: skill-name-here
+description: "What this skill does and when to use it."
+---
+
+# Skill Name
+
+[Introduction]
+
+## Quick Reference
+
+| Command | Purpose |
+|---------|---------|
+| `./scripts/helper.sh` | [What it does] |
+| `./scripts/validate.sh` | [What it does] |
+
+## Usage
+
+### Automated (Recommended)
+
+\`\`\`bash
+./skills/skill-name/scripts/helper.sh [args]
+\`\`\`
+
+### Manual Steps
+
+1. Step one
+2. Step two
+
+## Scripts
+
+| Script | Description |
+|--------|-------------|
+| `scripts/helper.sh` | Main utility |
+| `scripts/validate.sh` | Validation checker |
+
+## Source
+
+- Learning ID: LRN-YYYYMMDD-XXX
+```
+
+---
+
+## Naming Conventions
+
+- **Skill name**: lowercase, hyphens for spaces
+  - Good: `docker-m1-fixes`, `api-timeout-patterns`
+  - Bad: `Docker_M1_Fixes`, `APITimeoutPatterns`
+
+- **Description**: Start with action verb, mention trigger
+  - Good: "Handles Docker build failures on Apple Silicon. Use when builds fail with platform mismatch."
+  - Bad: "Docker stuff"
+
+- **Files**:
+  - `SKILL.md` - Required, main documentation
+  - `scripts/` - Optional, executable code
+  - `references/` - Optional, detailed docs
+  - `assets/` - Optional, templates
+
+---
+
+## Extraction Checklist
+
+Before creating a skill from a learning:
+
+- [ ] Learning is verified (status: resolved)
+- [ ] Solution is broadly applicable (not one-off)
+- [ ] Content is complete (has all needed context)
+- [ ] Name follows conventions
+- [ ] Description is concise but informative
+- [ ] Quick Reference table is actionable
+- [ ] Code examples are tested
+- [ ] Source learning ID is recorded
+
+After creating:
+
+- [ ] Update original learning with `promoted_to_skill` status
+- [ ] Add `Skill-Path: skills/skill-name` to learning metadata
+- [ ] Test skill by reading it in a fresh session

--- a/skill/self-improving-agent/hooks/openclaw/HOOK.md
+++ b/skill/self-improving-agent/hooks/openclaw/HOOK.md
@@ -1,0 +1,23 @@
+---
+name: self-improvement
+description: "Injects self-improvement reminder during agent bootstrap"
+metadata: {"openclaw":{"emoji":"🧠","events":["agent:bootstrap"]}}
+---
+
+# Self-Improvement Hook
+
+Injects a reminder to evaluate learnings during agent bootstrap.
+
+## What It Does
+
+- Fires on `agent:bootstrap` (before workspace files are injected)
+- Adds a reminder block to check `.learnings/` for relevant entries
+- Prompts the agent to log corrections, errors, and discoveries
+
+## Configuration
+
+No configuration needed. Enable with:
+
+```bash
+openclaw hooks enable self-improvement
+```

--- a/skill/self-improving-agent/hooks/openclaw/handler.js
+++ b/skill/self-improving-agent/hooks/openclaw/handler.js
@@ -1,0 +1,56 @@
+/**
+ * Self-Improvement Hook for OpenClaw
+ * 
+ * Injects a reminder to evaluate learnings during agent bootstrap.
+ * Fires on agent:bootstrap event before workspace files are injected.
+ */
+
+const REMINDER_CONTENT = `
+## Self-Improvement Reminder
+
+After completing tasks, evaluate if any learnings should be captured:
+
+**Log when:**
+- User corrects you → \`.learnings/LEARNINGS.md\`
+- Command/operation fails → \`.learnings/ERRORS.md\`
+- User wants missing capability → \`.learnings/FEATURE_REQUESTS.md\`
+- You discover your knowledge was wrong → \`.learnings/LEARNINGS.md\`
+- You find a better approach → \`.learnings/LEARNINGS.md\`
+
+**Promote when pattern is proven:**
+- Behavioral patterns → \`SOUL.md\`
+- Workflow improvements → \`AGENTS.md\`
+- Tool gotchas → \`TOOLS.md\`
+
+Keep entries simple: date, title, what happened, what to do differently.
+`.trim();
+
+const handler = async (event) => {
+  // Safety checks for event structure
+  if (!event || typeof event !== 'object') {
+    return;
+  }
+
+  // Only handle agent:bootstrap events
+  if (event.type !== 'agent' || event.action !== 'bootstrap') {
+    return;
+  }
+
+  // Safety check for context
+  if (!event.context || typeof event.context !== 'object') {
+    return;
+  }
+
+  // Inject the reminder as a virtual bootstrap file
+  // Check that bootstrapFiles is an array before pushing
+  if (Array.isArray(event.context.bootstrapFiles)) {
+    event.context.bootstrapFiles.push({
+      path: 'SELF_IMPROVEMENT_REMINDER.md',
+      content: REMINDER_CONTENT,
+      virtual: true,
+    });
+  }
+};
+
+module.exports = handler;
+module.exports.default = handler;

--- a/skill/self-improving-agent/hooks/openclaw/handler.ts
+++ b/skill/self-improving-agent/hooks/openclaw/handler.ts
@@ -1,0 +1,62 @@
+/**
+ * Self-Improvement Hook for OpenClaw
+ * 
+ * Injects a reminder to evaluate learnings during agent bootstrap.
+ * Fires on agent:bootstrap event before workspace files are injected.
+ */
+
+import type { HookHandler } from 'openclaw/hooks';
+
+const REMINDER_CONTENT = `## Self-Improvement Reminder
+
+After completing tasks, evaluate if any learnings should be captured:
+
+**Log when:**
+- User corrects you → \`.learnings/LEARNINGS.md\`
+- Command/operation fails → \`.learnings/ERRORS.md\`
+- User wants missing capability → \`.learnings/FEATURE_REQUESTS.md\`
+- You discover your knowledge was wrong → \`.learnings/LEARNINGS.md\`
+- You find a better approach → \`.learnings/LEARNINGS.md\`
+
+**Promote when pattern is proven:**
+- Behavioral patterns → \`SOUL.md\`
+- Workflow improvements → \`AGENTS.md\`
+- Tool gotchas → \`TOOLS.md\`
+
+Keep entries simple: date, title, what happened, what to do differently.`;
+
+const handler: HookHandler = async (event) => {
+  // Safety checks for event structure
+  if (!event || typeof event !== 'object') {
+    return;
+  }
+
+  // Only handle agent:bootstrap events
+  if (event.type !== 'agent' || event.action !== 'bootstrap') {
+    return;
+  }
+
+  // Safety check for context
+  if (!event.context || typeof event.context !== 'object') {
+    return;
+  }
+
+  // Skip sub-agent sessions to avoid bootstrap issues
+  // Sub-agents have sessionKey patterns like "agent:main:subagent:..."
+  const sessionKey = event.sessionKey || '';
+  if (sessionKey.includes(':subagent:')) {
+    return;
+  }
+
+  // Inject the reminder as a virtual bootstrap file
+  // Check that bootstrapFiles is an array before pushing
+  if (Array.isArray(event.context.bootstrapFiles)) {
+    event.context.bootstrapFiles.push({
+      path: 'SELF_IMPROVEMENT_REMINDER.md',
+      content: REMINDER_CONTENT,
+      virtual: true,
+    });
+  }
+};
+
+export default handler;

--- a/skill/self-improving-agent/references/examples.md
+++ b/skill/self-improving-agent/references/examples.md
@@ -1,0 +1,374 @@
+# Entry Examples
+
+Concrete examples of well-formatted entries with all fields.
+
+## Learning: Correction
+
+```markdown
+## [LRN-20250115-001] correction
+
+**Logged**: 2025-01-15T10:30:00Z
+**Priority**: high
+**Status**: pending
+**Area**: tests
+
+### Summary
+Incorrectly assumed pytest fixtures are scoped to function by default
+
+### Details
+When writing test fixtures, I assumed all fixtures were function-scoped. 
+User corrected that while function scope is the default, the codebase 
+convention uses module-scoped fixtures for database connections to 
+improve test performance.
+
+### Suggested Action
+When creating fixtures that involve expensive setup (DB, network), 
+check existing fixtures for scope patterns before defaulting to function scope.
+
+### Metadata
+- Source: user_feedback
+- Related Files: tests/conftest.py
+- Tags: pytest, testing, fixtures
+
+---
+```
+
+## Learning: Knowledge Gap (Resolved)
+
+```markdown
+## [LRN-20250115-002] knowledge_gap
+
+**Logged**: 2025-01-15T14:22:00Z
+**Priority**: medium
+**Status**: resolved
+**Area**: config
+
+### Summary
+Project uses pnpm not npm for package management
+
+### Details
+Attempted to run `npm install` but project uses pnpm workspaces.
+Lock file is `pnpm-lock.yaml`, not `package-lock.json`.
+
+### Suggested Action
+Check for `pnpm-lock.yaml` or `pnpm-workspace.yaml` before assuming npm.
+Use `pnpm install` for this project.
+
+### Metadata
+- Source: error
+- Related Files: pnpm-lock.yaml, pnpm-workspace.yaml
+- Tags: package-manager, pnpm, setup
+
+### Resolution
+- **Resolved**: 2025-01-15T14:30:00Z
+- **Commit/PR**: N/A - knowledge update
+- **Notes**: Added to CLAUDE.md for future reference
+
+---
+```
+
+## Learning: Promoted to CLAUDE.md
+
+```markdown
+## [LRN-20250115-003] best_practice
+
+**Logged**: 2025-01-15T16:00:00Z
+**Priority**: high
+**Status**: promoted
+**Promoted**: CLAUDE.md
+**Area**: backend
+
+### Summary
+API responses must include correlation ID from request headers
+
+### Details
+All API responses should echo back the X-Correlation-ID header from 
+the request. This is required for distributed tracing. Responses 
+without this header break the observability pipeline.
+
+### Suggested Action
+Always include correlation ID passthrough in API handlers.
+
+### Metadata
+- Source: user_feedback
+- Related Files: src/middleware/correlation.ts
+- Tags: api, observability, tracing
+
+---
+```
+
+## Learning: Promoted to AGENTS.md
+
+```markdown
+## [LRN-20250116-001] best_practice
+
+**Logged**: 2025-01-16T09:00:00Z
+**Priority**: high
+**Status**: promoted
+**Promoted**: AGENTS.md
+**Area**: backend
+
+### Summary
+Must regenerate API client after OpenAPI spec changes
+
+### Details
+When modifying API endpoints, the TypeScript client must be regenerated.
+Forgetting this causes type mismatches that only appear at runtime.
+The generate script also runs validation.
+
+### Suggested Action
+Add to agent workflow: after any API changes, run `pnpm run generate:api`.
+
+### Metadata
+- Source: error
+- Related Files: openapi.yaml, src/client/api.ts
+- Tags: api, codegen, typescript
+
+---
+```
+
+## Error Entry
+
+```markdown
+## [ERR-20250115-A3F] docker_build
+
+**Logged**: 2025-01-15T09:15:00Z
+**Priority**: high
+**Status**: pending
+**Area**: infra
+
+### Summary
+Docker build fails on M1 Mac due to platform mismatch
+
+### Error
+```
+error: failed to solve: python:3.11-slim: no match for platform linux/arm64
+```
+
+### Context
+- Command: `docker build -t myapp .`
+- Dockerfile uses `FROM python:3.11-slim`
+- Running on Apple Silicon (M1/M2)
+
+### Suggested Fix
+Add platform flag: `docker build --platform linux/amd64 -t myapp .`
+Or update Dockerfile: `FROM --platform=linux/amd64 python:3.11-slim`
+
+### Metadata
+- Reproducible: yes
+- Related Files: Dockerfile
+
+---
+```
+
+## Error Entry: Recurring Issue
+
+```markdown
+## [ERR-20250120-B2C] api_timeout
+
+**Logged**: 2025-01-20T11:30:00Z
+**Priority**: critical
+**Status**: pending
+**Area**: backend
+
+### Summary
+Third-party payment API timeout during checkout
+
+### Error
+```
+TimeoutError: Request to payments.example.com timed out after 30000ms
+```
+
+### Context
+- Command: POST /api/checkout
+- Timeout set to 30s
+- Occurs during peak hours (lunch, evening)
+
+### Suggested Fix
+Implement retry with exponential backoff. Consider circuit breaker pattern.
+
+### Metadata
+- Reproducible: yes (during peak hours)
+- Related Files: src/services/payment.ts
+- See Also: ERR-20250115-X1Y, ERR-20250118-Z3W
+
+---
+```
+
+## Feature Request
+
+```markdown
+## [FEAT-20250115-001] export_to_csv
+
+**Logged**: 2025-01-15T16:45:00Z
+**Priority**: medium
+**Status**: pending
+**Area**: backend
+
+### Requested Capability
+Export analysis results to CSV format
+
+### User Context
+User runs weekly reports and needs to share results with non-technical 
+stakeholders in Excel. Currently copies output manually.
+
+### Complexity Estimate
+simple
+
+### Suggested Implementation
+Add `--output csv` flag to the analyze command. Use standard csv module.
+Could extend existing `--output json` pattern.
+
+### Metadata
+- Frequency: recurring
+- Related Features: analyze command, json output
+
+---
+```
+
+## Feature Request: Resolved
+
+```markdown
+## [FEAT-20250110-002] dark_mode
+
+**Logged**: 2025-01-10T14:00:00Z
+**Priority**: low
+**Status**: resolved
+**Area**: frontend
+
+### Requested Capability
+Dark mode support for the dashboard
+
+### User Context
+User works late hours and finds the bright interface straining.
+Several other users have mentioned this informally.
+
+### Complexity Estimate
+medium
+
+### Suggested Implementation
+Use CSS variables for colors. Add toggle in user settings.
+Consider system preference detection.
+
+### Metadata
+- Frequency: recurring
+- Related Features: user settings, theme system
+
+### Resolution
+- **Resolved**: 2025-01-18T16:00:00Z
+- **Commit/PR**: #142
+- **Notes**: Implemented with system preference detection and manual toggle
+
+---
+```
+
+## Learning: Promoted to Skill
+
+```markdown
+## [LRN-20250118-001] best_practice
+
+**Logged**: 2025-01-18T11:00:00Z
+**Priority**: high
+**Status**: promoted_to_skill
+**Skill-Path**: skills/docker-m1-fixes
+**Area**: infra
+
+### Summary
+Docker build fails on Apple Silicon due to platform mismatch
+
+### Details
+When building Docker images on M1/M2 Macs, the build fails because
+the base image doesn't have an ARM64 variant. This is a common issue
+that affects many developers.
+
+### Suggested Action
+Add `--platform linux/amd64` to docker build command, or use
+`FROM --platform=linux/amd64` in Dockerfile.
+
+### Metadata
+- Source: error
+- Related Files: Dockerfile
+- Tags: docker, arm64, m1, apple-silicon
+- See Also: ERR-20250115-A3F, ERR-20250117-B2D
+
+---
+```
+
+## Extracted Skill Example
+
+When the above learning is extracted as a skill, it becomes:
+
+**File**: `skills/docker-m1-fixes/SKILL.md`
+
+```markdown
+---
+name: docker-m1-fixes
+description: "Fixes Docker build failures on Apple Silicon (M1/M2). Use when docker build fails with platform mismatch errors."
+---
+
+# Docker M1 Fixes
+
+Solutions for Docker build issues on Apple Silicon Macs.
+
+## Quick Reference
+
+| Error | Fix |
+|-------|-----|
+| `no match for platform linux/arm64` | Add `--platform linux/amd64` to build |
+| Image runs but crashes | Use emulation or find ARM-compatible base |
+
+## The Problem
+
+Many Docker base images don't have ARM64 variants. When building on
+Apple Silicon (M1/M2/M3), Docker attempts to pull ARM64 images by
+default, causing platform mismatch errors.
+
+## Solutions
+
+### Option 1: Build Flag (Recommended)
+
+Add platform flag to your build command:
+
+\`\`\`bash
+docker build --platform linux/amd64 -t myapp .
+\`\`\`
+
+### Option 2: Dockerfile Modification
+
+Specify platform in the FROM instruction:
+
+\`\`\`dockerfile
+FROM --platform=linux/amd64 python:3.11-slim
+\`\`\`
+
+### Option 3: Docker Compose
+
+Add platform to your service:
+
+\`\`\`yaml
+services:
+  app:
+    platform: linux/amd64
+    build: .
+\`\`\`
+
+## Trade-offs
+
+| Approach | Pros | Cons |
+|----------|------|------|
+| Build flag | No file changes | Must remember flag |
+| Dockerfile | Explicit, versioned | Affects all builds |
+| Compose | Convenient for dev | Requires compose |
+
+## Performance Note
+
+Running AMD64 images on ARM64 uses Rosetta 2 emulation. This works
+for development but may be slower. For production, find ARM-native
+alternatives when possible.
+
+## Source
+
+- Learning ID: LRN-20250118-001
+- Category: best_practice
+- Extraction Date: 2025-01-18
+```

--- a/skill/self-improving-agent/references/hooks-setup.md
+++ b/skill/self-improving-agent/references/hooks-setup.md
@@ -1,0 +1,223 @@
+# Hook Setup Guide
+
+Configure automatic self-improvement triggers for AI coding agents.
+
+## Overview
+
+Hooks enable proactive learning capture by injecting reminders at key moments:
+- **UserPromptSubmit**: Reminder after each prompt to evaluate learnings
+- **PostToolUse (Bash)**: Error detection when commands fail
+
+## Claude Code Setup
+
+### Option 1: Project-Level Configuration
+
+Create `.claude/settings.json` in your project root:
+
+```json
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "./skills/self-improvement/scripts/activator.sh"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "./skills/self-improvement/scripts/error-detector.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+### Option 2: User-Level Configuration
+
+Add to `~/.claude/settings.json` for global activation:
+
+```json
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/skills/self-improvement/scripts/activator.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+### Minimal Setup (Activator Only)
+
+For lower overhead, use only the UserPromptSubmit hook:
+
+```json
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "./skills/self-improvement/scripts/activator.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+## Codex CLI Setup
+
+Codex uses the same hook system as Claude Code. Create `.codex/settings.json`:
+
+```json
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "./skills/self-improvement/scripts/activator.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+## GitHub Copilot Setup
+
+Copilot doesn't support hooks directly. Instead, add guidance to `.github/copilot-instructions.md`:
+
+```markdown
+## Self-Improvement
+
+After completing tasks that involved:
+- Debugging non-obvious issues
+- Discovering workarounds
+- Learning project-specific patterns
+- Resolving unexpected errors
+
+Consider logging the learning to `.learnings/` using the format from the self-improvement skill.
+
+For high-value learnings that would benefit other sessions, consider skill extraction.
+```
+
+## Verification
+
+### Test Activator Hook
+
+1. Enable the hook configuration
+2. Start a new Claude Code session
+3. Send any prompt
+4. Verify you see `<self-improvement-reminder>` in the context
+
+### Test Error Detector Hook
+
+1. Enable PostToolUse hook for Bash
+2. Run a command that fails: `ls /nonexistent/path`
+3. Verify you see `<error-detected>` reminder
+
+### Dry Run Extract Script
+
+```bash
+./skills/self-improvement/scripts/extract-skill.sh test-skill --dry-run
+```
+
+Expected output shows the skill scaffold that would be created.
+
+## Troubleshooting
+
+### Hook Not Triggering
+
+1. **Check script permissions**: `chmod +x scripts/*.sh`
+2. **Verify path**: Use absolute paths or paths relative to project root
+3. **Check settings location**: Project vs user-level settings
+4. **Restart session**: Hooks are loaded at session start
+
+### Permission Denied
+
+```bash
+chmod +x ./skills/self-improvement/scripts/activator.sh
+chmod +x ./skills/self-improvement/scripts/error-detector.sh
+chmod +x ./skills/self-improvement/scripts/extract-skill.sh
+```
+
+### Script Not Found
+
+If using relative paths, ensure you're in the correct directory or use absolute paths:
+
+```json
+{
+  "command": "/absolute/path/to/skills/self-improvement/scripts/activator.sh"
+}
+```
+
+### Too Much Overhead
+
+If the activator feels intrusive:
+
+1. **Use minimal setup**: Only UserPromptSubmit, skip PostToolUse
+2. **Add matcher filter**: Only trigger for certain prompts:
+
+```json
+{
+  "matcher": "fix|debug|error|issue",
+  "hooks": [...]
+}
+```
+
+## Hook Output Budget
+
+The activator is designed to be lightweight:
+- **Target**: ~50-100 tokens per activation
+- **Content**: Structured reminder, not verbose instructions
+- **Format**: XML tags for easy parsing
+
+If you need to reduce overhead further, you can edit `activator.sh` to output less text.
+
+## Security Considerations
+
+- Hook scripts run with the same permissions as Claude Code
+- Scripts only output text; they don't modify files or run commands
+- Error detector reads `CLAUDE_TOOL_OUTPUT` environment variable
+- All scripts are opt-in (you must configure them explicitly)
+
+## Disabling Hooks
+
+To temporarily disable without removing configuration:
+
+1. **Comment out in settings**:
+```json
+{
+  "hooks": {
+    // "UserPromptSubmit": [...]
+  }
+}
+```
+
+2. **Or delete the settings file**: Hooks won't run without configuration

--- a/skill/self-improving-agent/references/openclaw-integration.md
+++ b/skill/self-improving-agent/references/openclaw-integration.md
@@ -1,0 +1,248 @@
+# OpenClaw Integration
+
+Complete setup and usage guide for integrating the self-improvement skill with OpenClaw.
+
+## Overview
+
+OpenClaw uses workspace-based prompt injection combined with event-driven hooks. Context is injected from workspace files at session start, and hooks can trigger on lifecycle events.
+
+## Workspace Structure
+
+```
+~/.openclaw/                      
+├── workspace/                   # Working directory
+│   ├── AGENTS.md               # Multi-agent coordination patterns
+│   ├── SOUL.md                 # Behavioral guidelines and personality
+│   ├── TOOLS.md                # Tool capabilities and gotchas
+│   ├── MEMORY.md               # Long-term memory (main session only)
+│   └── memory/                 # Daily memory files
+│       └── YYYY-MM-DD.md
+├── skills/                      # Installed skills
+│   └── <skill-name>/
+│       └── SKILL.md
+└── hooks/                       # Custom hooks
+    └── <hook-name>/
+        ├── HOOK.md
+        └── handler.ts
+```
+
+## Quick Setup
+
+### 1. Install the Skill
+
+```bash
+clawdhub install self-improving-agent
+```
+
+Or copy manually:
+
+```bash
+cp -r self-improving-agent ~/.openclaw/skills/
+```
+
+### 2. Install the Hook (Optional)
+
+Copy the hook to OpenClaw's hooks directory:
+
+```bash
+cp -r hooks/openclaw ~/.openclaw/hooks/self-improvement
+```
+
+Enable the hook:
+
+```bash
+openclaw hooks enable self-improvement
+```
+
+### 3. Create Learning Files
+
+Create the `.learnings/` directory in your workspace:
+
+```bash
+mkdir -p ~/.openclaw/workspace/.learnings
+```
+
+Or in the skill directory:
+
+```bash
+mkdir -p ~/.openclaw/skills/self-improving-agent/.learnings
+```
+
+## Injected Prompt Files
+
+### AGENTS.md
+
+Purpose: Multi-agent workflows and delegation patterns.
+
+```markdown
+# Agent Coordination
+
+## Delegation Rules
+- Use explore agent for open-ended codebase questions
+- Spawn sub-agents for long-running tasks
+- Use sessions_send for cross-session communication
+
+## Session Handoff
+When delegating to another session:
+1. Provide full context in the handoff message
+2. Include relevant file paths
+3. Specify expected output format
+```
+
+### SOUL.md
+
+Purpose: Behavioral guidelines and communication style.
+
+```markdown
+# Behavioral Guidelines
+
+## Communication Style
+- Be direct and concise
+- Avoid unnecessary caveats and disclaimers
+- Use technical language appropriate to context
+
+## Error Handling
+- Admit mistakes promptly
+- Provide corrected information immediately
+- Log significant errors to learnings
+```
+
+### TOOLS.md
+
+Purpose: Tool capabilities, integration gotchas, local configuration.
+
+```markdown
+# Tool Knowledge
+
+## Self-Improvement Skill
+Log learnings to `.learnings/` for continuous improvement.
+
+## Local Tools
+- Document tool-specific gotchas here
+- Note authentication requirements
+- Track integration quirks
+```
+
+## Learning Workflow
+
+### Capturing Learnings
+
+1. **In-session**: Log to `.learnings/` as usual
+2. **Cross-session**: Promote to workspace files
+
+### Promotion Decision Tree
+
+```
+Is the learning project-specific?
+├── Yes → Keep in .learnings/
+└── No → Is it behavioral/style-related?
+    ├── Yes → Promote to SOUL.md
+    └── No → Is it tool-related?
+        ├── Yes → Promote to TOOLS.md
+        └── No → Promote to AGENTS.md (workflow)
+```
+
+### Promotion Format Examples
+
+**From learning:**
+> Git push to GitHub fails without auth configured - triggers desktop prompt
+
+**To TOOLS.md:**
+```markdown
+## Git
+- Don't push without confirming auth is configured
+- Use `gh auth status` to check GitHub CLI auth
+```
+
+## Inter-Agent Communication
+
+OpenClaw provides tools for cross-session communication:
+
+### sessions_list
+
+View active and recent sessions:
+```
+sessions_list(activeMinutes=30, messageLimit=3)
+```
+
+### sessions_history
+
+Read transcript from another session:
+```
+sessions_history(sessionKey="session-id", limit=50)
+```
+
+### sessions_send
+
+Send message to another session:
+```
+sessions_send(sessionKey="session-id", message="Learning: API requires X-Custom-Header")
+```
+
+### sessions_spawn
+
+Spawn a background sub-agent:
+```
+sessions_spawn(task="Research X and report back", label="research")
+```
+
+## Available Hook Events
+
+| Event | When It Fires |
+|-------|---------------|
+| `agent:bootstrap` | Before workspace files inject |
+| `command:new` | When `/new` command issued |
+| `command:reset` | When `/reset` command issued |
+| `command:stop` | When `/stop` command issued |
+| `gateway:startup` | When gateway starts |
+
+## Detection Triggers
+
+### Standard Triggers
+- User corrections ("No, that's wrong...")
+- Command failures (non-zero exit codes)
+- API errors
+- Knowledge gaps
+
+### OpenClaw-Specific Triggers
+
+| Trigger | Action |
+|---------|--------|
+| Tool call error | Log to TOOLS.md with tool name |
+| Session handoff confusion | Log to AGENTS.md with delegation pattern |
+| Model behavior surprise | Log to SOUL.md with expected vs actual |
+| Skill issue | Log to .learnings/ or report upstream |
+
+## Verification
+
+Check hook is registered:
+
+```bash
+openclaw hooks list
+```
+
+Check skill is loaded:
+
+```bash
+openclaw status
+```
+
+## Troubleshooting
+
+### Hook not firing
+
+1. Ensure hooks enabled in config
+2. Restart gateway after config changes
+3. Check gateway logs for errors
+
+### Learnings not persisting
+
+1. Verify `.learnings/` directory exists
+2. Check file permissions
+3. Ensure workspace path is configured correctly
+
+### Skill not loading
+
+1. Check skill is in skills directory
+2. Verify SKILL.md has correct frontmatter
+3. Run `openclaw status` to see loaded skills

--- a/skill/self-improving-agent/scripts/activator.sh
+++ b/skill/self-improving-agent/scripts/activator.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Self-Improvement Activator Hook
+# Triggers on UserPromptSubmit to remind Claude about learning capture
+# Keep output minimal (~50-100 tokens) to minimize overhead
+
+set -e
+
+# Output reminder as system context
+cat << 'EOF'
+<self-improvement-reminder>
+After completing this task, evaluate if extractable knowledge emerged:
+- Non-obvious solution discovered through investigation?
+- Workaround for unexpected behavior?
+- Project-specific pattern learned?
+- Error required debugging to resolve?
+
+If yes: Log to .learnings/ using the self-improvement skill format.
+If high-value (recurring, broadly applicable): Consider skill extraction.
+</self-improvement-reminder>
+EOF

--- a/skill/self-improving-agent/scripts/error-detector.sh
+++ b/skill/self-improving-agent/scripts/error-detector.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# Self-Improvement Error Detector Hook
+# Triggers on PostToolUse for Bash to detect command failures
+# Reads CLAUDE_TOOL_OUTPUT environment variable
+
+set -e
+
+# Check if tool output indicates an error
+# CLAUDE_TOOL_OUTPUT contains the result of the tool execution
+OUTPUT="${CLAUDE_TOOL_OUTPUT:-}"
+
+# Patterns indicating errors (case-insensitive matching)
+ERROR_PATTERNS=(
+    "error:"
+    "Error:"
+    "ERROR:"
+    "failed"
+    "FAILED"
+    "command not found"
+    "No such file"
+    "Permission denied"
+    "fatal:"
+    "Exception"
+    "Traceback"
+    "npm ERR!"
+    "ModuleNotFoundError"
+    "SyntaxError"
+    "TypeError"
+    "exit code"
+    "non-zero"
+)
+
+# Check if output contains any error pattern
+contains_error=false
+for pattern in "${ERROR_PATTERNS[@]}"; do
+    if [[ "$OUTPUT" == *"$pattern"* ]]; then
+        contains_error=true
+        break
+    fi
+done
+
+# Only output reminder if error detected
+if [ "$contains_error" = true ]; then
+    cat << 'EOF'
+<error-detected>
+A command error was detected. Consider logging this to .learnings/ERRORS.md if:
+- The error was unexpected or non-obvious
+- It required investigation to resolve
+- It might recur in similar contexts
+- The solution could benefit future sessions
+
+Use the self-improvement skill format: [ERR-YYYYMMDD-XXX]
+</error-detected>
+EOF
+fi

--- a/skill/self-improving-agent/scripts/extract-skill.sh
+++ b/skill/self-improving-agent/scripts/extract-skill.sh
@@ -1,0 +1,221 @@
+#!/bin/bash
+# Skill Extraction Helper
+# Creates a new skill from a learning entry
+# Usage: ./extract-skill.sh <skill-name> [--dry-run]
+
+set -e
+
+# Configuration
+SKILLS_DIR="./skills"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+usage() {
+    cat << EOF
+Usage: $(basename "$0") <skill-name> [options]
+
+Create a new skill from a learning entry.
+
+Arguments:
+  skill-name     Name of the skill (lowercase, hyphens for spaces)
+
+Options:
+  --dry-run      Show what would be created without creating files
+  --output-dir   Relative output directory under current path (default: ./skills)
+  -h, --help     Show this help message
+
+Examples:
+  $(basename "$0") docker-m1-fixes
+  $(basename "$0") api-timeout-patterns --dry-run
+  $(basename "$0") pnpm-setup --output-dir ./skills/custom
+
+The skill will be created in: \$SKILLS_DIR/<skill-name>/
+EOF
+}
+
+log_info() {
+    echo -e "${GREEN}[INFO]${NC} $1"
+}
+
+log_warn() {
+    echo -e "${YELLOW}[WARN]${NC} $1"
+}
+
+log_error() {
+    echo -e "${RED}[ERROR]${NC} $1" >&2
+}
+
+# Parse arguments
+SKILL_NAME=""
+DRY_RUN=false
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --dry-run)
+            DRY_RUN=true
+            shift
+            ;;
+        --output-dir)
+            if [ -z "${2:-}" ] || [[ "${2:-}" == -* ]]; then
+                log_error "--output-dir requires a relative path argument"
+                usage
+                exit 1
+            fi
+            SKILLS_DIR="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        -*)
+            log_error "Unknown option: $1"
+            usage
+            exit 1
+            ;;
+        *)
+            if [ -z "$SKILL_NAME" ]; then
+                SKILL_NAME="$1"
+            else
+                log_error "Unexpected argument: $1"
+                usage
+                exit 1
+            fi
+            shift
+            ;;
+    esac
+done
+
+# Validate skill name
+if [ -z "$SKILL_NAME" ]; then
+    log_error "Skill name is required"
+    usage
+    exit 1
+fi
+
+# Validate skill name format (lowercase, hyphens, no spaces)
+if ! [[ "$SKILL_NAME" =~ ^[a-z0-9]+(-[a-z0-9]+)*$ ]]; then
+    log_error "Invalid skill name format. Use lowercase letters, numbers, and hyphens only."
+    log_error "Examples: 'docker-fixes', 'api-patterns', 'pnpm-setup'"
+    exit 1
+fi
+
+# Validate output path to avoid writes outside current workspace.
+if [[ "$SKILLS_DIR" = /* ]]; then
+    log_error "Output directory must be a relative path under the current directory."
+    exit 1
+fi
+
+if [[ "$SKILLS_DIR" =~ (^|/)\.\.(/|$) ]]; then
+    log_error "Output directory cannot include '..' path segments."
+    exit 1
+fi
+
+SKILLS_DIR="${SKILLS_DIR#./}"
+SKILLS_DIR="./$SKILLS_DIR"
+
+SKILL_PATH="$SKILLS_DIR/$SKILL_NAME"
+
+# Check if skill already exists
+if [ -d "$SKILL_PATH" ] && [ "$DRY_RUN" = false ]; then
+    log_error "Skill already exists: $SKILL_PATH"
+    log_error "Use a different name or remove the existing skill first."
+    exit 1
+fi
+
+# Dry run output
+if [ "$DRY_RUN" = true ]; then
+    log_info "Dry run - would create:"
+    echo "  $SKILL_PATH/"
+    echo "  $SKILL_PATH/SKILL.md"
+    echo ""
+    echo "Template content would be:"
+    echo "---"
+    cat << TEMPLATE
+name: $SKILL_NAME
+description: "[TODO: Add a concise description of what this skill does and when to use it]"
+---
+
+# $(echo "$SKILL_NAME" | sed 's/-/ /g' | awk '{for(i=1;i<=NF;i++) $i=toupper(substr($i,1,1)) tolower(substr($i,2))}1')
+
+[TODO: Brief introduction explaining the skill's purpose]
+
+## Quick Reference
+
+| Situation | Action |
+|-----------|--------|
+| [Trigger condition] | [What to do] |
+
+## Usage
+
+[TODO: Detailed usage instructions]
+
+## Examples
+
+[TODO: Add concrete examples]
+
+## Source Learning
+
+This skill was extracted from a learning entry.
+- Learning ID: [TODO: Add original learning ID]
+- Original File: .learnings/LEARNINGS.md
+TEMPLATE
+    echo "---"
+    exit 0
+fi
+
+# Create skill directory structure
+log_info "Creating skill: $SKILL_NAME"
+
+mkdir -p "$SKILL_PATH"
+
+# Create SKILL.md from template
+cat > "$SKILL_PATH/SKILL.md" << TEMPLATE
+---
+name: $SKILL_NAME
+description: "[TODO: Add a concise description of what this skill does and when to use it]"
+---
+
+# $(echo "$SKILL_NAME" | sed 's/-/ /g' | awk '{for(i=1;i<=NF;i++) $i=toupper(substr($i,1,1)) tolower(substr($i,2))}1')
+
+[TODO: Brief introduction explaining the skill's purpose]
+
+## Quick Reference
+
+| Situation | Action |
+|-----------|--------|
+| [Trigger condition] | [What to do] |
+
+## Usage
+
+[TODO: Detailed usage instructions]
+
+## Examples
+
+[TODO: Add concrete examples]
+
+## Source Learning
+
+This skill was extracted from a learning entry.
+- Learning ID: [TODO: Add original learning ID]
+- Original File: .learnings/LEARNINGS.md
+TEMPLATE
+
+log_info "Created: $SKILL_PATH/SKILL.md"
+
+# Suggest next steps
+echo ""
+log_info "Skill scaffold created successfully!"
+echo ""
+echo "Next steps:"
+echo "  1. Edit $SKILL_PATH/SKILL.md"
+echo "  2. Fill in the TODO sections with content from your learning"
+echo "  3. Add references/ folder if you have detailed documentation"
+echo "  4. Add scripts/ folder if you have executable code"
+echo "  5. Update the original learning entry with:"
+echo "     **Status**: promoted_to_skill"
+echo "     **Skill-Path**: skills/$SKILL_NAME"

--- a/skill/skill_readme.md
+++ b/skill/skill_readme.md
@@ -1,9 +1,20 @@
 # RDS Skills Documentation
 
-This repository provides two skills that can be used with Claude, OpenClaw, Claude Code, and similar platforms:
+This repository provides multiple skills that can be used with Claude, OpenClaw, Claude Code, and similar platforms:
+
+## Core RDS Skills
 
 1. **alibabacloud-rds-copilot**: Invokes the Alibaba Cloud RDS AI Assistant API for intelligent Q&A, SQL optimization, and troubleshooting.
 2. **alibabacloud-rds-instances-manage**: Exposes this project's **RDS OpenAPI tools** and **read-only SQL tools** via a **script/CLI**, so you can manage instances, query monitoring/slow logs/parameters, and run read-only SQL.
+
+## Additional Skills
+
+3. **mcporter**: Use the mcporter CLI to list, configure, auth, and call MCP servers/tools directly (HTTP or stdio), including ad-hoc servers, config edits, and CLI/type generation.
+4. **cli-anything**: Generate or refine agent-usable CLIs for existing software/codebases using the CLI-Anything methodology. Turn GUI apps, desktop tools, repositories, SDKs, or web/API surfaces into structured CLIs for agents.
+5. **data-analyst**: Data visualization, report generation, SQL queries, and spreadsheet automation. Transform your AI agent into a data-savvy analyst that turns raw data into actionable insights.
+6. **arxiv-watcher**: Search and summarize papers from ArXiv. Use when you need the latest research, specific topics on ArXiv, or a daily summary of AI papers.
+7. **duckdb-cli-ai-skills**: DuckDB CLI specialist for SQL analysis, data processing and file conversion. Use for SQL queries, CSV/Parquet/JSON analysis, database queries, or data conversion.
+8. **self-improving-agent**: Captures learnings, errors, and corrections to enable continuous improvement. Use when commands fail, users correct you, or better approaches are discovered.
 
 ---
 

--- a/skill/skill_readme_cn.md
+++ b/skill/skill_readme_cn.md
@@ -1,9 +1,20 @@
 # RDS 相关 Skills 使用说明
 
-本仓库提供两类 Skill，均可用于 Claude、OpenClaw、Claude Code 等以「技能」形式接入：
+本仓库提供多类 Skill，均可用于 Claude、OpenClaw、Claude Code 等以「技能」形式接入：
+
+## 核心 RDS Skills
 
 1. **alibabacloud-rds-copilot**：调用阿里云 RDS AI 助手 API，完成智能问答、SQL 优化、故障排查等。
 2. **alibabacloud-rds-instances-manage**：通过命令行直接调用本项目的 **RDS OpenAPI 工具** 与 **只读 SQL 工具**，管理实例、查监控/慢日志/参数、执行只读 SQL 等。
+
+## 其他 Skills
+
+3. **mcporter**：使用 mcporter CLI 直接列出、配置、认证和调用 MCP 服务器/工具（HTTP 或 stdio），包括临时服务器、配置编辑和 CLI/类型生成。
+4. **cli-anything**：使用 CLI-Anything 方法论为现有软件/代码库生成或改进适用于代理的 CLI。将 GUI 应用、桌面工具、仓库、SDK 或 Web/API 表面转换为适用于代理的结构化 CLI。
+5. **data-analyst**：数据可视化、报告生成、SQL 查询和电子表格自动化。将您的 AI 代理转变为精通数据的分析师，将原始数据转化为可操作的洞察。
+6. **arxiv-watcher**：搜索和总结 ArXiv 论文。当您需要最新研究、ArXiv 上的特定主题或 AI 论文的每日摘要时使用。
+7. **duckdb-cli-ai-skills**：DuckDB CLI 专家，用于 SQL 分析、数据处理和文件转换。用于 SQL 查询、CSV/Parquet/JSON 分析、数据库查询或数据转换。
+8. **self-improving-agent**：捕获学习、错误和更正以实现持续改进。当命令失败、用户纠正您或发现更好的方法时使用。
 
 ---
 


### PR DESCRIPTION
- Add mcporter: MCP server/tool CLI management
- Add cli-anything: Convert GUI apps/repos to agent-usable CLIs
- Add data-analyst: Data visualization, analysis, and reporting
- Add arxiv-watcher: Search and summarize ArXiv papers
- Add duckdb-cli-ai-skills: DuckDB SQL analysis and data processing
- Add self-improving-agent: Continuous improvement and learning logging
- Update skill_readme.md and skill_readme_cn.md with new skills descriptions
- Rename skill directories to remove version numbers