### PR TITLE
Fix session list spacing in IM markdown

### DIFF
--- a/rds-copilot-bot-gateway/core/bot_core.py
+++ b/rds-copilot-bot-gateway/core/bot_core.py
@@ -1267,7 +1267,7 @@ def format_conversations(conversations: list[dict], has_more: bool = False, lang
         conversation_id = item.get("Id") or item.get("id") or ""
         name = item.get("Name") or item.get("name") or _t(language, "conversation_untitled")
         updated_at = _format_created_at(_conversation_time_raw(item))
-        lines.append(f"- `{_short_id(conversation_id)}` `{updated_at}` {name}")
+        lines.append(f"- {_short_id(conversation_id)} | {updated_at} | {name}")
     if has_more:
         lines.append(f"\n{_t(language, 'more_conversations')}")
     return "\n".join(lines)

--- a/rds-copilot-bot-gateway/tests/test_bridge_and_api_coverage.py
+++ b/rds-copilot-bot-gateway/tests/test_bridge_and_api_coverage.py
@@ -707,8 +707,9 @@ class BotCoreCoverageTest(unittest.IsolatedAsyncioTestCase):
             True,
         )
         conversation_lines = conversations_text.splitlines()
-        self.assertEqual(conversation_lines[1], f"- `updatedf` `{bot_core._format_created_at(300)}` Updated")
-        self.assertEqual(conversation_lines[2], f"- `neweridf` `{bot_core._format_created_at(200)}` Newer")
+        self.assertEqual(conversation_lines[1], f"- updatedf | {bot_core._format_created_at(300)} | Updated")
+        self.assertEqual(conversation_lines[2], f"- neweridf | {bot_core._format_created_at(200)} | Newer")
+        self.assertNotRegex(conversation_lines[1], r"updatedf\\d{4}-\\d{2}-\\d{2}")
         self.assertNotIn("id=", conversations_text)
         self.assertNotIn("hidden intro", conversations_text)
         self.assertIn("还有更多对话", conversations_text)


### PR DESCRIPTION
## Summary

Fix `/session ls` output formatting in IM clients.

Some IM markdown renderers collapse adjacent inline-code spans, so the previous format:
